### PR TITLE
Add Fluent Docker Support To Benchmarks

### DIFF
--- a/test/UsageBenchmark/UsageBenchmark.csproj
+++ b/test/UsageBenchmark/UsageBenchmark.csproj
@@ -8,6 +8,7 @@
         <ProjectReference Include="..\..\src\Dapper.AOT.Analyzers\Dapper.AOT.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
         <ProjectReference Include="..\..\src\Dapper.AOT\Dapper.AOT.csproj" />
         <PackageReference Include="Dapper" Version="2.0.90" />
+        <PackageReference Include="Ductus.FluentDocker" Version="2.10.6" />
         <PackageReference Include="PooledAwait" Version="1.0.49" />
         <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />


### PR DESCRIPTION
This PR adds fluent docker as an option to run benchmarks
across all major operating systems as long as the host
has a docker instance running (docker desktop).

This PR is submitted with express premission from the author
to Marc Gravell with accordance with the project license.