### PR TITLE
make ef benchmarks produce results

### DIFF
--- a/test/UsageBenchmark/BatchInsertBenchmarks.cs
+++ b/test/UsageBenchmark/BatchInsertBenchmarks.cs
@@ -1,7 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore;
 using System;
 using System.Data;
 using System.Data.Common;
@@ -16,7 +15,6 @@ public class BatchInsertBenchmarks : IDisposable
 {
     private readonly SqlConnection connection = new(Program.ConnectionString);
     private Customer[] customers = Array.Empty<Customer>();
-    private readonly MyContext ctx = new();
 
     public BatchInsertBenchmarks()
     {
@@ -34,9 +32,9 @@ public class BatchInsertBenchmarks : IDisposable
     public void Setup()
     {
         var arr = new Customer[Count];
-        for (int i = 0; i < arr.Length; i++)
+        for (int i = 1; i <= arr.Length; i++)
         {
-            arr[i] = new Customer { Id = i, Name = "Name " + i };
+            arr[i - 1] = new Customer { Id = i, Name = "Name " + i };
         }
         customers = arr;
         if (IsOpen)
@@ -172,20 +170,10 @@ public class BatchInsertBenchmarks : IDisposable
         }
     }
 
-    [RunOncePerIteration]
-    public void ResetIds()
-    {
-        // this is mostly because EF is going to update the values,
-        // triggering identity-insert violations on the *next* attempt
-        foreach (var customer in customers)
-        {
-            customer.Id = 0;
-        }
-    }
-
     [Benchmark, BenchmarkCategory("Sync")]
     public int EntityFramework()
     {
+        using var ctx = new MyContext();
         ctx.Customers.AddRange(customers);
         var result = ctx.SaveChanges();
         ctx.ChangeTracker.Clear();
@@ -195,6 +183,7 @@ public class BatchInsertBenchmarks : IDisposable
     [Benchmark, BenchmarkCategory("Async")]
     public async Task<int> EntityFrameworkAsync()
     {
+        using var ctx = new MyContext();
         ctx.Customers.AddRange(customers);
         var result = await ctx.SaveChangesAsync();
         ctx.ChangeTracker.Clear();
@@ -262,7 +251,6 @@ public class BatchInsertBenchmarks : IDisposable
     public void Dispose()
     {
         connection.Dispose();
-        ctx.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/test/UsageBenchmark/BatchInsertBenchmarks.txt
+++ b/test/UsageBenchmark/BatchInsertBenchmarks.txt
@@ -1,141 +1,151 @@
-﻿|                     Method | Categories | Count | IsOpen |                Mean |               Error |             StdDev |     Ratio |  RatioSD |    Gen0 |   Gen1 | Allocated | Alloc Ratio |
-|--------------------------- |----------- |------ |------- |--------------------:|--------------------:|-------------------:|----------:|---------:|--------:|-------:|----------:|------------:|
-|                DapperAsync |      Async |     0 |  False |       8,121.1950 ns |       1,884.2487 ns |        103.2820 ns |    731.18 |     8.86 |  0.1526 |      - |    1344 B |          NA |
-|             DapperAotAsync |      Async |     0 |  False |          15.1765 ns |           0.6666 ns |          0.0365 ns |      1.37 |     0.00 |       - |      - |         - |          NA |
-|    DapperAot_PreparedAsync |      Async |     0 |  False |          15.1907 ns |           0.6531 ns |          0.0358 ns |      1.37 |     0.00 |       - |      - |         - |          NA |
-|                ManualAsync |      Async |     0 |  False |          11.1069 ns |           0.3880 ns |          0.0213 ns |      1.00 |     0.00 |       - |      - |         - |          NA |
-|       EntityFrameworkAsync |      Async |     0 |  False |      81,548.4131 ns |      12,747.1175 ns |        698.7125 ns |  7,342.11 |    53.58 |  7.8125 | 0.6104 |   65802 B |          NA |
-| SqlBulkCopyFastMemberAsync |      Async |     0 |  False |      26,119.5658 ns |       8,861.2169 ns |        485.7132 ns |  2,351.68 |    45.16 |  0.7629 |      - |    6454 B |          NA |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |     0 |   True |         175.6700 ns |          60.2217 ns |          3.3010 ns |     15.08 |     0.28 |  0.0391 |      - |     328 B |          NA |
-|             DapperAotAsync |      Async |     0 |   True |          15.1730 ns |           1.2404 ns |          0.0680 ns |      1.30 |     0.01 |       - |      - |         - |          NA |
-|    DapperAot_PreparedAsync |      Async |     0 |   True |          15.1567 ns |           0.6286 ns |          0.0345 ns |      1.30 |     0.00 |       - |      - |         - |          NA |
-|                ManualAsync |      Async |     0 |   True |          11.6505 ns |           0.1321 ns |          0.0072 ns |      1.00 |     0.00 |       - |      - |         - |          NA |
-|       EntityFrameworkAsync |      Async |     0 |   True |      81,872.2290 ns |      17,851.6310 ns |        978.5081 ns |  7,027.32 |    81.07 |  7.8125 | 0.6104 |   65802 B |          NA |
-| SqlBulkCopyFastMemberAsync |      Async |     0 |   True |       9,460.3572 ns |       1,188.6807 ns |         65.1556 ns |    812.01 |     5.72 |  0.6409 |      - |    5433 B |          NA |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |     1 |  False |     260,926.1393 ns |      86,804.7326 ns |      4,758.0603 ns |      1.02 |     0.02 |  0.4883 |      - |    4592 B |        1.45 |
-|             DapperAotAsync |      Async |     1 |  False |     253,833.0892 ns |     128,683.2028 ns |      7,053.5606 ns |      0.99 |     0.02 |       - |      - |    3192 B |        1.01 |
-|    DapperAot_PreparedAsync |      Async |     1 |  False |     254,843.0990 ns |     130,485.0546 ns |      7,152.3261 ns |      0.99 |     0.03 |       - |      - |    3192 B |        1.01 |
-|                ManualAsync |      Async |     1 |  False |     256,180.1595 ns |      14,012.3150 ns |        768.0623 ns |      1.00 |     0.00 |       - |      - |    3176 B |        1.00 |
-|       EntityFrameworkAsync |      Async |     1 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |     1 |  False |   1,312,030.4036 ns |     170,983.3461 ns |      9,372.1742 ns |      5.12 |     0.02 |       - |      - |   15255 B |        4.80 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |     1 |   True |     225,040.5111 ns |      18,299.2146 ns |      1,003.0417 ns |      0.99 |     0.01 |  0.2441 |      - |    3392 B |        1.72 |
-|             DapperAotAsync |      Async |     1 |   True |     221,289.1602 ns |      35,385.7889 ns |      1,939.6145 ns |      0.97 |     0.01 |       - |      - |    1992 B |        1.01 |
-|    DapperAot_PreparedAsync |      Async |     1 |   True |     221,813.0290 ns |      54,610.5298 ns |      2,993.3874 ns |      0.97 |     0.02 |       - |      - |    1992 B |        1.01 |
-|                ManualAsync |      Async |     1 |   True |     227,772.7539 ns |      37,164.6674 ns |      2,037.1208 ns |      1.00 |     0.00 |       - |      - |    1976 B |        1.00 |
-|       EntityFrameworkAsync |      Async |     1 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |     1 |   True |   1,215,880.5339 ns |     826,827.6762 ns |     45,321.2149 ns |      5.34 |     0.25 |       - |      - |   14057 B |        7.11 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |    10 |  False |   2,135,963.9323 ns |     694,430.6667 ns |     38,064.0881 ns |      1.01 |     0.02 |       - |      - |   21588 B |        1.36 |
-|             DapperAotAsync |      Async |    10 |  False |   2,160,731.6406 ns |     290,647.4665 ns |     15,931.3684 ns |      1.03 |     0.02 |       - |      - |   18740 B |        1.18 |
-|    DapperAot_PreparedAsync |      Async |    10 |  False |   2,091,742.3177 ns |     855,176.8387 ns |     46,875.1282 ns |      0.99 |     0.03 |       - |      - |   15916 B |        1.00 |
-|                ManualAsync |      Async |    10 |  False |   2,108,143.3594 ns |     495,587.1878 ns |     27,164.8060 ns |      1.00 |     0.00 |       - |      - |   15908 B |        1.00 |
-|       EntityFrameworkAsync |      Async |    10 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |    10 |  False |   1,380,058.2682 ns |     484,543.3834 ns |     26,559.4579 ns |      0.65 |     0.02 |  1.9531 |      - |   20170 B |        1.27 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |    10 |   True |   2,114,031.9010 ns |     468,736.3034 ns |     25,693.0185 ns |      1.00 |     0.01 |       - |      - |   20388 B |        1.44 |
-|             DapperAotAsync |      Async |    10 |   True |   2,128,270.0521 ns |     507,412.4346 ns |     27,812.9877 ns |      1.01 |     0.01 |       - |      - |   17540 B |        1.24 |
-|    DapperAot_PreparedAsync |      Async |    10 |   True |   2,063,326.9531 ns |     241,086.3013 ns |     13,214.7537 ns |      0.98 |     0.00 |       - |      - |   14180 B |        1.00 |
-|                ManualAsync |      Async |    10 |   True |   2,107,939.8438 ns |      92,416.5014 ns |      5,065.6603 ns |      1.00 |     0.00 |       - |      - |   14172 B |        1.00 |
-|       EntityFrameworkAsync |      Async |    10 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |    10 |   True |   1,331,852.9297 ns |     129,497.3306 ns |      7,098.1857 ns |      0.63 |     0.00 |  1.9531 |      - |   18970 B |        1.34 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |   100 |  False |  21,441,097.9167 ns |   1,050,522.4731 ns |     57,582.6816 ns |      1.03 |     0.03 |       - |      - |  191534 B |        1.36 |
-|             DapperAotAsync |      Async |   100 |  False |  20,900,296.8750 ns |   5,119,043.5616 ns |    280,592.0510 ns |      1.01 |     0.03 |       - |      - |  174286 B |        1.23 |
-|    DapperAot_PreparedAsync |      Async |   100 |  False |  20,576,431.2500 ns |   2,397,174.1689 ns |    131,397.2051 ns |      0.99 |     0.03 |       - |      - |  141222 B |        1.00 |
-|                ManualAsync |      Async |   100 |  False |  20,797,761.4583 ns |  12,024,048.6072 ns |    659,078.6775 ns |      1.00 |     0.00 |       - |      - |  141214 B |        1.00 |
-|       EntityFrameworkAsync |      Async |   100 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |   100 |  False |   1,667,992.0573 ns |     681,775.3543 ns |     37,370.4077 ns |      0.08 |     0.00 |  7.8125 |      - |   69163 B |        0.49 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |   100 |   True |  20,963,698.9583 ns |   2,694,337.0210 ns |    147,685.7038 ns |      1.02 |     0.02 |       - |      - |  190334 B |        1.36 |
-|             DapperAotAsync |      Async |   100 |   True |  20,902,609.3750 ns |  12,008,673.5340 ns |    658,235.9179 ns |      1.02 |     0.05 |       - |      - |  173086 B |        1.24 |
-|    DapperAot_PreparedAsync |      Async |   100 |   True |  20,403,641.6667 ns |   3,086,626.1808 ns |    169,188.3963 ns |      0.99 |     0.01 |       - |      - |  139486 B |        1.00 |
-|                ManualAsync |      Async |   100 |   True |  20,548,645.8333 ns |   8,088,473.6488 ns |    443,356.5340 ns |      1.00 |     0.00 |       - |      - |  139478 B |        1.00 |
-|       EntityFrameworkAsync |      Async |   100 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |   100 |   True |   1,592,285.0911 ns |     146,600.0181 ns |      8,035.6417 ns |      0.08 |     0.00 |  7.8125 |      - |   67961 B |        0.49 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |  1000 |  False | 213,876,433.3333 ns |  54,160,480.1893 ns |  2,968,718.6755 ns |      1.04 |     0.03 |       - |      - | 1891072 B |        1.36 |
-|             DapperAotAsync |      Async |  1000 |  False | 207,014,488.8889 ns |  41,882,587.8469 ns |  2,295,725.9664 ns |      1.00 |     0.02 |       - |      - | 1729824 B |        1.24 |
-|    DapperAot_PreparedAsync |      Async |  1000 |  False | 202,722,800.0000 ns |  54,766,339.4555 ns |  3,001,927.8663 ns |      0.98 |     0.02 |       - |      - | 1394360 B |        1.00 |
-|                ManualAsync |      Async |  1000 |  False | 206,042,511.1111 ns |  65,200,475.6074 ns |  3,573,858.0772 ns |      1.00 |     0.00 |       - |      - | 1394352 B |        1.00 |
-|       EntityFrameworkAsync |      Async |  1000 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |  1000 |  False |   4,455,957.8125 ns |      89,460.0649 ns |      4,903.6080 ns |      0.02 |     0.00 | 62.5000 |      - |  559321 B |        0.40 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                DapperAsync |      Async |  1000 |   True | 219,932,277.7778 ns | 208,078,856.4901 ns | 11,405,504.2549 ns |      0.98 |     0.04 |       - |      - | 1889824 B |        1.36 |
-|             DapperAotAsync |      Async |  1000 |   True | 228,504,488.8889 ns | 148,465,632.1028 ns |  8,137,902.2704 ns |      1.02 |     0.08 |       - |      - | 1728576 B |        1.24 |
-|    DapperAot_PreparedAsync |      Async |  1000 |   True | 206,092,333.3333 ns |  20,524,848.4472 ns |  1,125,036.2014 ns |      0.92 |     0.05 |       - |      - | 1392576 B |        1.00 |
-|                ManualAsync |      Async |  1000 |   True | 224,849,477.7778 ns | 221,981,888.8009 ns | 12,167,576.3695 ns |      1.00 |     0.00 |       - |      - | 1392568 B |        1.00 |
-|       EntityFrameworkAsync |      Async |  1000 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-| SqlBulkCopyFastMemberAsync |      Async |  1000 |   True |   4,431,620.0521 ns |   1,251,644.5590 ns |     68,606.8618 ns |      0.02 |     0.00 | 62.5000 |      - |  558128 B |        0.40 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |     0 |  False |       7,903.7847 ns |       1,456.1306 ns |         79.8154 ns |  7,841.92 |   222.35 |  0.1373 |      - |    1152 B |          NA |
-|                  DapperAot |       Sync |     0 |  False |          12.0525 ns |           0.7243 ns |          0.0397 ns |     11.96 |     0.47 |       - |      - |         - |          NA |
-|         DapperAot_Prepared |       Sync |     0 |  False |          12.1749 ns |           0.6474 ns |          0.0355 ns |     12.08 |     0.45 |       - |      - |         - |          NA |
-|                     Manual |       Sync |     0 |  False |           1.0086 ns |           0.6925 ns |          0.0380 ns |      1.00 |     0.00 |       - |      - |         - |          NA |
-|            EntityFramework |       Sync |     0 |  False |      81,282.7230 ns |       3,498.3961 ns |        191.7589 ns | 80,662.93 | 2,923.75 |  7.8125 | 0.6104 |   65802 B |          NA |
-|      SqlBulkCopyFastMember |       Sync |     0 |  False |      17,022.2900 ns |       2,799.9082 ns |        153.4724 ns | 16,891.37 |   585.70 |  0.6104 |      - |    5121 B |          NA |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |     0 |   True |         150.4443 ns |          82.7556 ns |          4.5361 ns |    157.22 |     5.16 |  0.0391 |      - |     328 B |          NA |
-|                  DapperAot |       Sync |     0 |   True |          12.2705 ns |           2.6446 ns |          0.1450 ns |     12.82 |     0.11 |       - |      - |         - |          NA |
-|         DapperAot_Prepared |       Sync |     0 |   True |          12.1469 ns |           1.5046 ns |          0.0825 ns |     12.69 |     0.06 |       - |      - |         - |          NA |
-|                     Manual |       Sync |     0 |   True |           0.9570 ns |           0.0846 ns |          0.0046 ns |      1.00 |     0.00 |       - |      - |         - |          NA |
-|            EntityFramework |       Sync |     0 |   True |      81,541.1580 ns |       4,361.8756 ns |        239.0891 ns | 85,210.00 |   612.20 |  7.8125 | 0.6104 |   65802 B |          NA |
-|      SqlBulkCopyFastMember |       Sync |     0 |   True |       6,560.9591 ns |         812.5540 ns |         44.5388 ns |  6,856.27 |    79.96 |  0.5112 | 0.0076 |    4296 B |          NA |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |     1 |  False |     221,010.7015 ns |      51,565.3466 ns |      2,826.4706 ns |      0.95 |     0.02 |  0.2441 |      - |    2648 B |        1.92 |
-|                  DapperAot |       Sync |     1 |  False |     221,397.2249 ns |      28,392.0089 ns |      1,556.2618 ns |      0.95 |     0.01 |       - |      - |    1376 B |        1.00 |
-|         DapperAot_Prepared |       Sync |     1 |  False |     233,384.4808 ns |      37,970.0555 ns |      2,081.2669 ns |      1.01 |     0.01 |       - |      - |    1376 B |        1.00 |
-|                     Manual |       Sync |     1 |  False |     232,008.0648 ns |      58,221.5791 ns |      3,191.3212 ns |      1.00 |     0.00 |       - |      - |    1376 B |        1.00 |
-|            EntityFramework |       Sync |     1 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |     1 |  False |   1,196,390.1042 ns |     659,378.8685 ns |     36,142.7808 ns |      5.16 |     0.15 |       - |      - |   12478 B |        9.07 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |     1 |   True |     192,313.8509 ns |      12,206.5393 ns |        669.0816 ns |      0.94 |     0.02 |       - |      - |    1640 B |        4.46 |
-|                  DapperAot |       Sync |     1 |   True |     192,857.2998 ns |      48,397.1311 ns |      2,652.8101 ns |      0.94 |     0.02 |       - |      - |     368 B |        1.00 |
-|         DapperAot_Prepared |       Sync |     1 |   True |     199,363.0208 ns |      28,804.2332 ns |      1,578.8572 ns |      0.98 |     0.02 |       - |      - |     368 B |        1.00 |
-|                     Manual |       Sync |     1 |   True |     204,161.2793 ns |      92,211.9577 ns |      5,054.4486 ns |      1.00 |     0.00 |       - |      - |     368 B |        1.00 |
-|            EntityFramework |       Sync |     1 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |     1 |   True |   1,120,835.0911 ns |     394,061.8313 ns |     21,599.8587 ns |      5.49 |     0.06 |       - |      - |   11470 B |       31.17 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |    10 |  False |   1,978,139.3229 ns |   1,382,455.0350 ns |     75,777.0254 ns |      1.03 |     0.04 |       - |      - |    7403 B |        3.97 |
-|                  DapperAot |       Sync |    10 |  False |   1,990,212.4023 ns |     132,605.5024 ns |      7,268.5550 ns |      1.04 |     0.01 |       - |      - |    4689 B |        2.51 |
-|         DapperAot_Prepared |       Sync |    10 |  False |   1,926,515.5599 ns |     310,353.7044 ns |     17,011.5338 ns |      1.00 |     0.01 |       - |      - |    1865 B |        1.00 |
-|                     Manual |       Sync |    10 |  False |   1,920,558.5286 ns |     173,194.2472 ns |      9,493.3611 ns |      1.00 |     0.00 |       - |      - |    1867 B |        1.00 |
-|            EntityFramework |       Sync |    10 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |    10 |  False |   1,219,800.5859 ns |     589,286.5613 ns |     32,300.7849 ns |      0.64 |     0.01 |       - |      - |   12478 B |        6.68 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |    10 |   True |   1,952,304.2969 ns |     183,460.7059 ns |     10,056.1004 ns |      1.05 |     0.01 |       - |      - |    6395 B |       19.92 |
-|                  DapperAot |       Sync |    10 |   True |   1,945,141.5365 ns |     361,301.8654 ns |     19,804.1744 ns |      1.05 |     0.02 |       - |      - |    3683 B |       11.47 |
-|         DapperAot_Prepared |       Sync |    10 |   True |   1,865,769.7266 ns |     204,328.0720 ns |     11,199.9111 ns |      1.01 |     0.01 |       - |      - |     321 B |        1.00 |
-|                     Manual |       Sync |    10 |   True |   1,854,322.1354 ns |     213,644.9504 ns |     11,710.6006 ns |      1.00 |     0.00 |       - |      - |     321 B |        1.00 |
-|            EntityFramework |       Sync |    10 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |    10 |   True |   1,089,936.3281 ns |     339,935.3483 ns |     18,633.0035 ns |      0.59 |     0.01 |       - |      - |   11470 B |       35.73 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |   100 |  False |  18,954,120.8333 ns |   3,985,389.4604 ns |    218,452.6444 ns |      1.01 |     0.00 |       - |      - |   54941 B |       11.53 |
-|                  DapperAot |       Sync |   100 |  False |  19,266,117.7083 ns |   2,017,996.9200 ns |    110,613.2206 ns |      1.03 |     0.01 |       - |      - |   37829 B |        7.94 |
-|         DapperAot_Prepared |       Sync |   100 |  False |  18,947,792.7083 ns |   2,677,091.9441 ns |    146,740.4429 ns |      1.01 |     0.00 |       - |      - |    4765 B |        1.00 |
-|                     Manual |       Sync |   100 |  False |  18,739,771.8750 ns |   2,573,440.0538 ns |    141,058.9330 ns |      1.00 |     0.00 |       - |      - |    4765 B |        1.00 |
-|            EntityFramework |       Sync |   100 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |   100 |  False |   1,442,990.9505 ns |     145,702.1002 ns |      7,986.4238 ns |      0.08 |     0.00 |       - |      - |   12478 B |        2.62 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |   100 |   True |  18,902,367.7083 ns |     489,950.5081 ns |     26,855.8406 ns |      0.99 |     0.02 |       - |      - |   53933 B |       16.74 |
-|                  DapperAot |       Sync |   100 |   True |  19,079,340.6250 ns |   1,572,011.0168 ns |     86,167.2283 ns |      0.99 |     0.02 |       - |      - |   36821 B |       11.43 |
-|         DapperAot_Prepared |       Sync |   100 |   True |  18,732,453.1250 ns |   2,951,565.8376 ns |    161,785.2832 ns |      0.98 |     0.03 |       - |      - |    3221 B |        1.00 |
-|                     Manual |       Sync |   100 |   True |  19,190,822.9167 ns |   8,771,720.4909 ns |    480,807.5990 ns |      1.00 |     0.00 |       - |      - |    3221 B |        1.00 |
-|            EntityFramework |       Sync |   100 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |   100 |   True |   1,357,357.8125 ns |     162,883.2162 ns |      8,928.1787 ns |      0.07 |     0.00 |       - |      - |   11470 B |        3.56 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |  1000 |  False | 194,548,855.5556 ns |  64,972,210.5505 ns |  3,561,346.0992 ns |      0.98 |     0.02 |       - |      - |  530392 B |       15.68 |
-|                  DapperAot |       Sync |  1000 |  False | 190,902,300.0000 ns |  17,169,100.6606 ns |    941,096.3417 ns |      0.96 |     0.00 |       - |      - |  369280 B |       10.92 |
-|         DapperAot_Prepared |       Sync |  1000 |  False | 193,677,177.7778 ns |  31,448,680.6054 ns |  1,723,808.3028 ns |      0.98 |     0.02 |       - |      - |   33816 B |        1.00 |
-|                     Manual |       Sync |  1000 |  False | 198,167,277.7778 ns |  34,619,639.0775 ns |  1,897,619.2366 ns |      1.00 |     0.00 |       - |      - |   33816 B |        1.00 |
-|            EntityFramework |       Sync |  1000 |  False |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |  1000 |  False |   3,810,317.9688 ns |   4,952,775.7784 ns |    271,478.3528 ns |      0.02 |     0.00 |       - |      - |   12500 B |        0.37 |
-|                            |            |       |        |                     |                     |                    |           |          |         |        |           |             |
-|                     Dapper |       Sync |  1000 |   True | 187,374,722.2222 ns |  31,034,928.8237 ns |  1,701,129.1715 ns |      1.00 |     0.01 |       - |      - |  529336 B |       16.43 |
-|                  DapperAot |       Sync |  1000 |   True | 189,848,900.0000 ns |  43,257,055.3612 ns |  2,371,065.1687 ns |      1.02 |     0.01 |       - |      - |  368224 B |       11.43 |
-|         DapperAot_Prepared |       Sync |  1000 |   True | 184,528,788.8889 ns |  17,896,373.3025 ns |    980,960.6093 ns |      0.99 |     0.00 |       - |      - |   32224 B |        1.00 |
-|                     Manual |       Sync |  1000 |   True | 186,788,300.0000 ns |   6,223,904.4184 ns |    341,153.2028 ns |      1.00 |     0.00 |       - |      - |   32224 B |        1.00 |
-|            EntityFramework |       Sync |  1000 |   True |                  NA |                  NA |                 NA |         ? |        ? |       - |      - |         - |           ? |
-|      SqlBulkCopyFastMember |       Sync |  1000 |   True |   3,533,560.5469 ns |      64,995.2886 ns |      3,562.6111 ns |      0.02 |     0.00 |       - |      - |   11492 B |        0.36 |
+﻿|                     Method | Categories | Count | IsOpen |               Mean |               Error |             StdDev |     Ratio |   RatioSD |     Gen0 |     Gen1 | Allocated | Alloc Ratio |
+|--------------------------- |----------- |------ |------- |-------------------:|--------------------:|-------------------:|----------:|----------:|---------:|---------:|----------:|------------:|
+|                DapperAsync |      Async |     0 |  False |       5,775.176 ns |         843.0607 ns |         46.2110 ns |    311.85 |     26.04 |   0.2136 |        - |    1352 B |          NA |
+|             DapperAotAsync |      Async |     0 |  False |          19.923 ns |          22.0846 ns |          1.2105 ns |      1.07 |      0.02 |        - |        - |         - |          NA |
+|    DapperAot_PreparedAsync |      Async |     0 |  False |          24.534 ns |          31.4597 ns |          1.7244 ns |      1.33 |      0.19 |        - |        - |         - |          NA |
+|                ManualAsync |      Async |     0 |  False |          18.594 ns |          24.4553 ns |          1.3405 ns |      1.00 |      0.00 |        - |        - |         - |          NA |
+|       EntityFrameworkAsync |      Async |     0 |  False |      99,391.854 ns |      27,549.0879 ns |      1,510.0585 ns |  5,362.65 |    363.84 |  10.8643 |   0.8545 |   68539 B |          NA |
+| SqlBulkCopyFastMemberAsync |      Async |     0 |  False |      61,448.096 ns |     121,796.0355 ns |      6,676.0517 ns |  3,302.01 |    206.08 |   1.3428 |        - |    8801 B |          NA |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |     0 |   True |         202.962 ns |          39.0271 ns |          2.1392 ns |     15.49 |      0.68 |   0.0520 |        - |     328 B |          NA |
+|             DapperAotAsync |      Async |     0 |   True |          19.534 ns |           5.6233 ns |          0.3082 ns |      1.49 |      0.09 |        - |        - |         - |          NA |
+|    DapperAot_PreparedAsync |      Async |     0 |   True |          20.141 ns |          11.0958 ns |          0.6082 ns |      1.54 |      0.08 |        - |        - |         - |          NA |
+|                ManualAsync |      Async |     0 |   True |          13.120 ns |          10.9672 ns |          0.6011 ns |      1.00 |      0.00 |        - |        - |         - |          NA |
+|       EntityFrameworkAsync |      Async |     0 |   True |      94,132.125 ns |      70,731.0184 ns |      3,877.0058 ns |  7,176.03 |     35.61 |  10.8643 |   0.8545 |   68539 B |          NA |
+| SqlBulkCopyFastMemberAsync |      Async |     0 |   True |      19,074.833 ns |      14,774.7160 ns |        809.8520 ns |  1,455.39 |     74.78 |   1.2207 |        - |    7717 B |          NA |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |     1 |  False |     244,743.587 ns |     185,812.2207 ns |     10,184.9948 ns |      1.06 |      0.11 |   0.4883 |        - |    4416 B |        1.47 |
+|             DapperAotAsync |      Async |     1 |  False |     282,947.005 ns |     554,181.9170 ns |     30,376.5809 ns |      1.23 |      0.21 |        - |        - |    3016 B |        1.01 |
+|    DapperAot_PreparedAsync |      Async |     1 |  False |     271,112.158 ns |     331,360.6560 ns |     18,162.9957 ns |      1.17 |      0.12 |        - |        - |    3016 B |        1.01 |
+|                ManualAsync |      Async |     1 |  False |     232,475.895 ns |     330,112.6934 ns |     18,094.5906 ns |      1.00 |      0.00 |        - |        - |    3000 B |        1.00 |
+|       EntityFrameworkAsync |      Async |     1 |  False |     619,396.615 ns |   1,789,059.7011 ns |     98,064.3991 ns |      2.68 |      0.47 |  13.6719 |   0.9766 |   86520 B |       28.84 |
+| SqlBulkCopyFastMemberAsync |      Async |     1 |  False |   1,270,683.398 ns |     962,688.5795 ns |     52,768.2095 ns |      5.49 |      0.59 |   1.9531 |        - |   17510 B |        5.84 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |     1 |   True |     220,988.354 ns |      99,587.8351 ns |      5,458.7453 ns |      1.14 |      0.10 |   0.4883 |        - |    3208 B |        1.79 |
+|             DapperAotAsync |      Async |     1 |   True |     209,151.335 ns |     134,686.2250 ns |      7,382.6065 ns |      1.07 |      0.03 |   0.2441 |        - |    1808 B |        1.01 |
+|    DapperAot_PreparedAsync |      Async |     1 |   True |     204,188.737 ns |     242,255.7990 ns |     13,278.8578 ns |      1.05 |      0.01 |   0.2441 |        - |    1808 B |        1.01 |
+|                ManualAsync |      Async |     1 |   True |     194,806.128 ns |     209,041.6019 ns |     11,458.2756 ns |      1.00 |      0.00 |   0.2441 |        - |    1792 B |        1.00 |
+|       EntityFrameworkAsync |      Async |     1 |   True |     557,586.263 ns |   1,107,936.1864 ns |     60,729.7209 ns |      2.86 |      0.24 |  13.6719 |        - |   86564 B |       48.31 |
+| SqlBulkCopyFastMemberAsync |      Async |     1 |   True |   1,156,145.898 ns |     250,439.4235 ns |     13,727.4299 ns |      5.95 |      0.41 |   1.9531 |        - |   16254 B |        9.07 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |    10 |  False |   1,943,253.646 ns |     219,688.8181 ns |     12,041.8854 ns |      1.06 |      0.02 |        - |        - |   19756 B |        1.40 |
+|             DapperAotAsync |      Async |    10 |  False |   2,088,771.354 ns |   1,219,487.9819 ns |     66,844.2513 ns |      1.14 |      0.02 |        - |        - |   16908 B |        1.20 |
+|    DapperAot_PreparedAsync |      Async |    10 |  False |   1,999,634.766 ns |     698,105.0614 ns |     38,265.4941 ns |      1.09 |      0.03 |        - |        - |   14084 B |        1.00 |
+|                ManualAsync |      Async |    10 |  False |   1,831,214.714 ns |     696,312.0223 ns |     38,167.2115 ns |      1.00 |      0.00 |        - |        - |   14076 B |        1.00 |
+|       EntityFrameworkAsync |      Async |    10 |  False |   1,073,383.464 ns |   2,311,343.5081 ns |    126,692.5370 ns |      0.59 |      0.07 |  21.4844 |   1.9531 |  138285 B |        9.82 |
+| SqlBulkCopyFastMemberAsync |      Async |    10 |  False |   1,275,561.914 ns |     437,536.6074 ns |     23,982.8579 ns |      0.70 |      0.00 |   1.9531 |        - |   22350 B |        1.59 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |    10 |   True |   1,998,707.422 ns |     780,628.1426 ns |     42,788.8626 ns |      0.86 |      0.08 |        - |        - |   18548 B |        1.50 |
+|             DapperAotAsync |      Async |    10 |   True |   2,239,787.500 ns |   2,029,978.3340 ns |    111,269.9623 ns |      0.96 |      0.03 |        - |        - |   15700 B |        1.27 |
+|    DapperAot_PreparedAsync |      Async |    10 |   True |   2,340,979.036 ns |   1,626,148.0757 ns |     89,134.6632 ns |      1.01 |      0.07 |        - |        - |   12876 B |        1.04 |
+|                ManualAsync |      Async |    10 |   True |   2,331,943.099 ns |   3,128,968.5511 ns |    171,509.3245 ns |      1.00 |      0.00 |        - |        - |   12332 B |        1.00 |
+|       EntityFrameworkAsync |      Async |    10 |   True |     706,300.456 ns |     115,347.0074 ns |      6,322.5587 ns |      0.30 |      0.02 |  21.4844 |   1.9531 |  138286 B |       11.21 |
+| SqlBulkCopyFastMemberAsync |      Async |    10 |   True |   1,228,874.935 ns |     602,566.8063 ns |     33,028.7199 ns |      0.53 |      0.05 |   1.9531 |        - |   21140 B |        1.71 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |   100 |  False |  19,066,323.958 ns |   7,481,906.8453 ns |    410,108.5608 ns |      1.01 |      0.05 |        - |        - |  173144 B |        1.41 |
+|             DapperAotAsync |      Async |   100 |  False |  18,052,265.625 ns |   2,710,845.1353 ns |    148,590.5692 ns |      0.95 |      0.07 |        - |        - |  155896 B |        1.27 |
+|    DapperAot_PreparedAsync |      Async |   100 |  False |  17,420,162.500 ns |  21,665,484.8684 ns |  1,187,558.3325 ns |      0.92 |      0.03 |        - |        - |  122832 B |        1.00 |
+|                ManualAsync |      Async |   100 |  False |  18,991,740.625 ns |  22,549,032.9795 ns |  1,235,988.5859 ns |      1.00 |      0.00 |        - |        - |  122824 B |        1.00 |
+|       EntityFrameworkAsync |      Async |   100 |  False |   2,613,160.938 ns |   1,749,123.6318 ns |     95,875.3684 ns |      0.14 |      0.01 | 101.5625 |  23.4375 |  653611 B |        5.32 |
+| SqlBulkCopyFastMemberAsync |      Async |   100 |  False |   2,688,343.880 ns |   6,404,175.0185 ns |    351,034.4427 ns |      0.14 |      0.03 |   7.8125 |        - |   71382 B |        0.58 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |   100 |   True |  19,721,491.667 ns |   2,239,326.3996 ns |    122,745.0362 ns |      1.15 |      0.05 |        - |        - |  171936 B |        1.42 |
+|             DapperAotAsync |      Async |   100 |   True |  19,168,511.458 ns |   8,746,072.8317 ns |    479,401.7642 ns |      1.11 |      0.02 |        - |        - |  154688 B |        1.28 |
+|    DapperAot_PreparedAsync |      Async |   100 |   True |  18,133,390.625 ns |  23,685,163.1413 ns |  1,298,263.7138 ns |      1.06 |      0.11 |        - |        - |  121624 B |        1.00 |
+|                ManualAsync |      Async |   100 |   True |  17,206,466.667 ns |  12,410,729.6602 ns |    680,273.9708 ns |      1.00 |      0.00 |        - |        - |  121080 B |        1.00 |
+|       EntityFrameworkAsync |      Async |   100 |   True |   2,469,998.047 ns |   1,531,338.5043 ns |     83,937.8307 ns |      0.14 |      0.00 | 101.5625 |  23.4375 |  653611 B |        5.40 |
+| SqlBulkCopyFastMemberAsync |      Async |   100 |   True |   1,980,046.224 ns |   5,226,038.0610 ns |    286,456.7806 ns |      0.12 |      0.02 |   9.7656 |        - |   70162 B |        0.58 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |  1000 |  False | 244,920,466.667 ns | 722,345,752.1038 ns | 39,594,208.1194 ns |      1.18 |      0.17 |        - |        - | 1707101 B |        1.41 |
+|             DapperAotAsync |      Async |  1000 |  False | 241,934,933.333 ns | 644,925,597.8512 ns | 35,350,548.2222 ns |      1.17 |      0.15 |        - |        - | 1546024 B |        1.28 |
+|    DapperAot_PreparedAsync |      Async |  1000 |  False | 241,673,133.333 ns | 643,416,413.5380 ns | 35,267,824.7375 ns |      1.16 |      0.15 |        - |        - | 1210552 B |        1.00 |
+|                ManualAsync |      Async |  1000 |  False | 207,144,611.111 ns |  83,705,530.6571 ns |  4,588,182.5870 ns |      1.00 |      0.00 |        - |        - | 1210544 B |        1.00 |
+|       EntityFrameworkAsync |      Async |  1000 |  False |  25,646,712.500 ns |  18,988,250.2531 ns |  1,040,810.0694 ns |      0.12 |      0.00 | 875.0000 | 500.0000 | 5811264 B |        4.80 |
+| SqlBulkCopyFastMemberAsync |      Async |  1000 |  False |   7,087,480.469 ns |  14,534,217.2575 ns |    796,669.4914 ns |      0.03 |      0.00 |  85.9375 |        - |  561950 B |        0.46 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                DapperAsync |      Async |  1000 |   True | 218,505,733.333 ns | 286,272,659.2652 ns | 15,691,570.4382 ns |      1.05 |      0.10 |        - |        - | 1706016 B |        1.41 |
+|             DapperAotAsync |      Async |  1000 |   True | 227,333,633.333 ns | 293,364,389.9597 ns | 16,080,292.1275 ns |      1.09 |      0.03 |        - |        - | 1544768 B |        1.28 |
+|    DapperAot_PreparedAsync |      Async |  1000 |   True | 225,050,783.333 ns | 252,684,982.6387 ns | 13,850,516.5457 ns |      1.09 |      0.10 |        - |        - | 1209304 B |        1.00 |
+|                ManualAsync |      Async |  1000 |   True | 208,179,166.667 ns | 373,052,034.7243 ns | 20,448,240.8310 ns |      1.00 |      0.00 |        - |        - | 1208589 B |        1.00 |
+|       EntityFrameworkAsync |      Async |  1000 |   True |  27,036,673.958 ns |  18,661,487.1332 ns |  1,022,899.0801 ns |      0.13 |      0.01 | 906.2500 | 656.2500 | 5807400 B |        4.81 |
+| SqlBulkCopyFastMemberAsync |      Async |  1000 |   True |   7,473,611.458 ns |   2,787,123.6749 ns |    152,771.6533 ns |      0.04 |      0.00 |  78.1250 |        - |  560711 B |        0.46 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |     0 |  False |       5,337.417 ns |       4,729.8064 ns |        259.2566 ns |  3,580.49 |    967.76 |   0.1831 |        - |    1160 B |          NA |
+|                  DapperAot |       Sync |     0 |  False |       5,521.688 ns |      11,629.3165 ns |        637.4421 ns |  3,613.45 |    497.34 |   0.1831 |        - |    1160 B |          NA |
+|            DapperAotManual |       Sync |     0 |  False |          16.111 ns |          18.5808 ns |          1.0185 ns |     10.66 |      2.13 |        - |        - |         - |          NA |
+|   DapperAot_PreparedManual |       Sync |     0 |  False |          15.639 ns |          14.9445 ns |          0.8192 ns |     10.46 |      2.66 |        - |        - |         - |          NA |
+|                     Manual |       Sync |     0 |  False |           1.567 ns |           7.7090 ns |          0.4226 ns |      1.00 |      0.00 |        - |        - |         - |          NA |
+|            EntityFramework |       Sync |     0 |  False |     108,843.412 ns |     242,806.7182 ns |     13,309.0555 ns | 72,852.23 | 20,619.98 |  10.8643 |   0.8545 |   68539 B |          NA |
+|      SqlBulkCopyFastMember |       Sync |     0 |  False |      32,364.954 ns |      22,805.9900 ns |      1,250.0733 ns | 21,493.05 |  4,756.04 |   1.1597 |        - |    7411 B |          NA |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |     0 |   True |         190.847 ns |         280.6369 ns |         15.3827 ns |    134.57 |      9.52 |   0.0522 |        - |     328 B |          NA |
+|                  DapperAot |       Sync |     0 |   True |         173.953 ns |         149.7267 ns |          8.2070 ns |    122.78 |      7.51 |   0.0522 |        - |     328 B |          NA |
+|            DapperAotManual |       Sync |     0 |   True |          14.992 ns |           8.5481 ns |          0.4685 ns |     10.58 |      0.60 |        - |        - |         - |          NA |
+|   DapperAot_PreparedManual |       Sync |     0 |   True |          15.423 ns |           4.5787 ns |          0.2510 ns |     10.88 |      0.39 |        - |        - |         - |          NA |
+|                     Manual |       Sync |     0 |   True |           1.418 ns |           0.6903 ns |          0.0378 ns |      1.00 |      0.00 |        - |        - |         - |          NA |
+|            EntityFramework |       Sync |     0 |   True |     100,803.015 ns |      67,996.1381 ns |      3,727.0978 ns | 71,107.93 |  2,498.13 |  10.8643 |   0.8545 |   68539 B |          NA |
+|      SqlBulkCopyFastMember |       Sync |     0 |   True |      11,247.035 ns |       8,890.5383 ns |        487.3204 ns |  7,936.33 |    414.54 |   1.0376 |        - |    6577 B |          NA |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |     1 |  False |     235,726.156 ns |     286,850.5089 ns |     15,723.2443 ns |      1.09 |      0.08 |        - |        - |    2656 B |        1.92 |
+|                  DapperAot |       Sync |     1 |  False |     241,722.103 ns |     434,717.0487 ns |     23,828.3083 ns |      1.12 |      0.11 |        - |        - |    2656 B |        1.92 |
+|            DapperAotManual |       Sync |     1 |  False |     216,983.993 ns |      63,507.4147 ns |      3,481.0557 ns |      1.00 |      0.02 |        - |        - |    1384 B |        1.00 |
+|   DapperAot_PreparedManual |       Sync |     1 |  False |     212,597.087 ns |     218,982.9575 ns |     12,003.1948 ns |      0.98 |      0.05 |        - |        - |    1384 B |        1.00 |
+|                     Manual |       Sync |     1 |  False |     216,150.545 ns |      36,057.6678 ns |      1,976.4424 ns |      1.00 |      0.00 |        - |        - |    1384 B |        1.00 |
+|            EntityFramework |       Sync |     1 |  False |     556,974.316 ns |   1,164,276.6945 ns |     63,817.9343 ns |      2.58 |      0.27 |  12.6953 |   0.9766 |   82831 B |       59.85 |
+|      SqlBulkCopyFastMember |       Sync |     1 |  False |   1,671,856.250 ns |   3,308,521.8543 ns |    181,351.2469 ns |      7.73 |      0.77 |   1.9531 |        - |   14681 B |       10.61 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |     1 |   True |     200,716.577 ns |      52,683.5359 ns |      2,887.7624 ns |      1.09 |      0.02 |   0.2441 |        - |    1640 B |        4.46 |
+|                  DapperAot |       Sync |     1 |   True |     189,281.657 ns |      39,384.3577 ns |      2,158.7895 ns |      1.03 |      0.01 |   0.2441 |        - |    1640 B |        4.46 |
+|            DapperAotManual |       Sync |     1 |   True |     191,043.132 ns |     662,016.8527 ns |     36,287.3776 ns |      1.03 |      0.18 |        - |        - |     368 B |        1.00 |
+|   DapperAot_PreparedManual |       Sync |     1 |   True |     175,379.720 ns |     287,027.6139 ns |     15,732.9521 ns |      0.95 |      0.09 |        - |        - |     368 B |        1.00 |
+|                     Manual |       Sync |     1 |   True |     184,483.602 ns |      61,599.1822 ns |      3,376.4590 ns |      1.00 |      0.00 |        - |        - |     368 B |        1.00 |
+|            EntityFramework |       Sync |     1 |   True |     580,407.878 ns |     862,468.5502 ns |     47,274.8115 ns |      3.15 |      0.25 |  12.6953 |   0.9766 |   82831 B |      225.08 |
+|      SqlBulkCopyFastMember |       Sync |     1 |   True |   1,536,496.484 ns |   2,386,567.5384 ns |    130,815.8199 ns |      8.34 |      0.84 |   1.9531 |        - |   13665 B |       37.13 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |    10 |  False |   2,130,205.339 ns |  10,150,903.4323 ns |    556,405.2698 ns |      1.26 |      0.31 |        - |        - |    7411 B |        3.95 |
+|                  DapperAot |       Sync |    10 |  False |   1,919,208.984 ns |   1,193,240.9035 ns |     65,405.5603 ns |      1.13 |      0.01 |        - |        - |    7411 B |        3.95 |
+|            DapperAotManual |       Sync |    10 |  False |   1,934,656.966 ns |     235,069.3010 ns |     12,884.9416 ns |      1.14 |      0.03 |        - |        - |    4697 B |        2.51 |
+|   DapperAot_PreparedManual |       Sync |    10 |  False |   2,263,917.904 ns |     528,143.7373 ns |     28,949.3404 ns |      1.34 |      0.06 |        - |        - |    1875 B |        1.00 |
+|                     Manual |       Sync |    10 |  False |   1,692,380.469 ns |   1,014,281.5016 ns |     55,596.1916 ns |      1.00 |      0.00 |        - |        - |    1875 B |        1.00 |
+|            EntityFramework |       Sync |    10 |  False |     844,905.632 ns |   1,257,783.7782 ns |     68,943.3731 ns |      0.50 |      0.05 |  20.5078 |   1.9531 |  134501 B |       71.73 |
+|      SqlBulkCopyFastMember |       Sync |    10 |  False |   1,389,812.760 ns |   2,416,018.5399 ns |    132,430.1287 ns |      0.82 |      0.05 |   1.9531 |        - |   14681 B |        7.83 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |    10 |   True |   1,672,365.495 ns |   1,487,092.3186 ns |     81,512.5480 ns |      0.98 |      0.07 |        - |        - |    6395 B |       19.92 |
+|                  DapperAot |       Sync |    10 |   True |   1,823,836.393 ns |   2,054,541.9496 ns |    112,616.3770 ns |      1.07 |      0.09 |        - |        - |    6393 B |       19.92 |
+|            DapperAotManual |       Sync |    10 |   True |   1,854,710.677 ns |   2,484,190.6058 ns |    136,166.8696 ns |      1.09 |      0.10 |        - |        - |    3683 B |       11.47 |
+|   DapperAot_PreparedManual |       Sync |    10 |   True |   1,700,834.440 ns |     728,364.9820 ns |     39,924.1424 ns |      1.00 |      0.08 |        - |        - |     857 B |        2.67 |
+|                     Manual |       Sync |    10 |   True |   1,708,965.951 ns |   1,932,689.0981 ns |    105,937.2110 ns |      1.00 |      0.00 |        - |        - |     321 B |        1.00 |
+|            EntityFramework |       Sync |    10 |   True |     854,281.185 ns |   2,056,028.4127 ns |    112,697.8551 ns |      0.50 |      0.07 |  20.5078 |   1.9531 |  134501 B |      419.01 |
+|      SqlBulkCopyFastMember |       Sync |    10 |   True |   1,726,131.120 ns |     434,729.4781 ns |     23,828.9896 ns |      1.01 |      0.05 |   1.9531 |        - |   13665 B |       42.57 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |   100 |  False |  17,277,327.083 ns |     544,111.9926 ns |     29,824.6143 ns |      0.99 |      0.01 |        - |        - |   54951 B |       11.51 |
+|                  DapperAot |       Sync |   100 |  False |  17,307,260.417 ns |   4,618,921.9268 ns |    253,178.6967 ns |      0.99 |      0.02 |        - |        - |   54951 B |       11.51 |
+|            DapperAotManual |       Sync |   100 |  False |  23,713,331.250 ns |  59,210,532.8484 ns |  3,245,529.1024 ns |      1.35 |      0.18 |        - |        - |   37839 B |        7.92 |
+|   DapperAot_PreparedManual |       Sync |   100 |  False |  18,241,156.250 ns |  27,864,387.1832 ns |  1,527,341.0857 ns |      1.04 |      0.08 |        - |        - |    4775 B |        1.00 |
+|                     Manual |       Sync |   100 |  False |  17,540,770.833 ns |   1,554,037.8314 ns |     85,182.0574 ns |      1.00 |      0.00 |        - |        - |    4775 B |        1.00 |
+|            EntityFramework |       Sync |   100 |  False |   3,263,590.104 ns |   2,340,646.1136 ns |    128,298.7116 ns |      0.19 |      0.01 | 101.5625 |  23.4375 |  644568 B |      134.99 |
+|      SqlBulkCopyFastMember |       Sync |   100 |  False |   2,282,882.943 ns |   1,564,156.3391 ns |     85,736.6870 ns |      0.13 |      0.00 |        - |        - |   14687 B |        3.08 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |   100 |   True |  18,622,282.292 ns |  12,614,780.6994 ns |    691,458.6968 ns |      1.06 |      0.05 |        - |        - |   53935 B |       16.73 |
+|                  DapperAot |       Sync |   100 |   True |  17,213,685.417 ns |  12,949,425.5012 ns |    709,801.7076 ns |      0.98 |      0.09 |        - |        - |   53935 B |       16.73 |
+|            DapperAotManual |       Sync |   100 |   True |  17,227,790.625 ns |   6,610,063.4932 ns |    362,319.8847 ns |      0.98 |      0.04 |        - |        - |   36823 B |       11.43 |
+|   DapperAot_PreparedManual |       Sync |   100 |   True |  17,804,769.792 ns |  38,799,415.0059 ns |  2,126,726.8592 ns |      1.02 |      0.18 |        - |        - |    3759 B |        1.17 |
+|                     Manual |       Sync |   100 |   True |  17,586,519.792 ns |  18,396,614.1847 ns |  1,008,380.5001 ns |      1.00 |      0.00 |        - |        - |    3223 B |        1.00 |
+|            EntityFramework |       Sync |   100 |   True |   3,358,126.302 ns |     166,360.3488 ns |      9,118.7721 ns |      0.19 |      0.01 | 101.5625 |  23.4375 |  644568 B |      199.99 |
+|      SqlBulkCopyFastMember |       Sync |   100 |   True |   2,051,506.120 ns |   2,137,278.0213 ns |    117,151.4203 ns |      0.12 |      0.00 |        - |        - |   13671 B |        4.24 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |  1000 |  False | 168,068,244.444 ns |  54,547,400.0894 ns |  2,989,927.0609 ns |      1.01 |      0.02 |        - |        - |  530421 B |       15.67 |
+|                  DapperAot |       Sync |  1000 |  False | 178,125,522.222 ns |  18,395,469.3183 ns |  1,008,317.7461 ns |      1.07 |      0.02 |        - |        - |  530421 B |       15.67 |
+|            DapperAotManual |       Sync |  1000 |  False | 172,509,666.667 ns |  11,556,953.6225 ns |    633,475.6252 ns |      1.04 |      0.02 |        - |        - |  369309 B |       10.91 |
+|   DapperAot_PreparedManual |       Sync |  1000 |  False | 206,656,255.556 ns | 159,939,773.8061 ns |  8,766,838.6949 ns |      1.25 |      0.05 |        - |        - |   33845 B |        1.00 |
+|                     Manual |       Sync |  1000 |  False | 165,769,600.000 ns |  58,141,982.0614 ns |  3,186,958.2281 ns |      1.00 |      0.00 |        - |        - |   33845 B |        1.00 |
+|            EntityFramework |       Sync |  1000 |  False |  22,991,938.542 ns |   2,855,594.8421 ns |    156,524.7891 ns |      0.14 |      0.00 | 906.2500 | 718.7500 | 5745568 B |      169.76 |
+|      SqlBulkCopyFastMember |       Sync |  1000 |  False |   4,546,077.344 ns |   7,808,541.5099 ns |    428,012.5089 ns |      0.03 |      0.00 |        - |        - |   14742 B |        0.44 |
+|                            |            |       |        |                    |                     |                    |           |           |          |          |           |             |
+|                     Dapper |       Sync |  1000 |   True | 167,939,844.444 ns | 144,672,496.6227 ns |  7,929,987.7154 ns |      0.74 |      0.03 |        - |        - |  529357 B |       16.42 |
+|                  DapperAot |       Sync |  1000 |   True | 176,908,733.333 ns | 159,058,640.9359 ns |  8,718,540.8290 ns |      0.78 |      0.04 |        - |        - |  529357 B |       16.42 |
+|            DapperAotManual |       Sync |  1000 |   True | 177,458,111.111 ns | 156,038,627.2569 ns |  8,553,003.6887 ns |      0.79 |      0.04 |        - |        - |  368245 B |       11.42 |
+|   DapperAot_PreparedManual |       Sync |  1000 |   True | 174,787,955.556 ns | 146,247,576.7979 ns |  8,016,323.1746 ns |      0.78 |      0.06 |        - |        - |   32781 B |        1.02 |
+|                     Manual |       Sync |  1000 |   True | 225,532,411.111 ns | 148,623,516.5636 ns |  8,146,556.4505 ns |      1.00 |      0.00 |        - |        - |   32245 B |        1.00 |
+|            EntityFramework |       Sync |  1000 |   True |  23,227,266.667 ns |   5,219,852.8606 ns |    286,117.7489 ns |      0.10 |      0.00 | 906.2500 | 718.7500 | 5745568 B |      178.18 |
+|      SqlBulkCopyFastMember |       Sync |  1000 |   True |   4,981,081.771 ns |   4,605,205.1727 ns |    252,426.8351 ns |      0.02 |      0.00 |        - |        - |   13726 B |        0.43 |

--- a/test/UsageBenchmark/Program.cs
+++ b/test/UsageBenchmark/Program.cs
@@ -32,34 +32,22 @@ static class Program
             obj.IsOpen = isOpen;
             obj.Setup();
 
-            obj.ResetIds();
             Console.WriteLine(obj.Manual());
-            obj.ResetIds();
             Console.WriteLine(await obj.ManualAsync());
 
-            obj.ResetIds();
             Console.WriteLine(obj.Dapper());
-            obj.ResetIds();
             Console.WriteLine(await obj.DapperAsync());
 
-            obj.ResetIds();
             Console.WriteLine(obj.DapperAotManual());
-            obj.ResetIds();
             Console.WriteLine(await obj.DapperAotAsync());
 
-            obj.ResetIds();
             Console.WriteLine(obj.DapperAot_PreparedManual());
-            obj.ResetIds();
             Console.WriteLine(await obj.DapperAot_PreparedAsync());
 
-            obj.ResetIds();
             Console.WriteLine(obj.EntityFramework());
-            obj.ResetIds();
             Console.WriteLine(await obj.EntityFrameworkAsync());
 
-            obj.ResetIds();
             Console.WriteLine(obj.SqlBulkCopyFastMember());
-            obj.ResetIds();
             Console.WriteLine(await obj.SqlBulkCopyFastMemberAsync());
         }
 

--- a/test/UsageBenchmark/Shared.cs
+++ b/test/UsageBenchmark/Shared.cs
@@ -1,15 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System.ComponentModel.DataAnnotations.Schema;
 using UsageBenchmark;
 
 namespace Dapper;
 
 public class Customer
 {
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
 
     [DbValue(Size = 400)]
@@ -20,14 +18,15 @@ public class MyContext : DbContext
 {
     public DbSet<Customer> Customers { get; set; }
 
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseSqlServer(Program.ConnectionString);
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder
+        .UseSqlServer(Program.ConnectionString)
+        .EnableSensitiveDataLogging();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
         => modelBuilder.Entity<Customer>(entity =>
         {
             entity.ToTable("BenchmarkCustomers");
-            entity.Property<int>(nameof(Customer.Id)).ValueGeneratedOnAdd().UseIdentityColumn(1, 1);
+            entity.Property<int>(nameof(Customer.Id)).ValueGeneratedOnAdd().Metadata.SetBeforeSaveBehavior(PropertySaveBehavior.Ignore);
             entity.Property<string>(nameof(Customer.Name));
         });
 }


### PR DESCRIPTION
note: i am not sure if what I have done is really the best idea in terms of EF, but there is no exception in the runtime now.

re results of local benchmark: curious to see EF being faster than Dapper to be honest. I dont understand how that can happen (for example on 1000 row insert). It allocates much more, but execution time is a bit strange. If you want, I can remove the .txt output and you can rerun on your PC.

```
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1848/22H2/2022Update/SunValley2)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100-preview.4.23260.5
  [Host]   : .NET 8.0.0 (8.0.23.25905), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.0 (8.0.23.25905), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3
```