### PR TITLE
feat(typeaccessor): add isnull custom implementation

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
@@ -431,6 +431,13 @@ namespace Dapper.CodeAnalysis
 
                 foreach (var member in members.Where(x => x.IsNullable))
                 {
+                    if (IsDBNull(member.TypeSymbol))
+                    {
+                        // if member is of type DBNull, then it is always null => simply return true
+                        _sb.Append(member.Number).Append(" => true,").NewLine();
+                        continue;
+                    }
+
                     _sb.Append(member.Number).Append(" => obj.").Append(member.Name).Append(" is null");
                     if (member.TypeSymbol.IsSystemObject())
                     {
@@ -441,6 +448,12 @@ namespace Dapper.CodeAnalysis
 
                 _sb.Append("_ => base.IsNull(obj, index)")
                    .Outdent().Append(";").NewLine();
+
+                bool IsDBNull(ITypeSymbol typeSymbol)
+                {
+                    return typeSymbol.ContainingNamespace.Name == "System"
+                        && typeSymbol.Name == "DBNull";
+                }
             }
 
             public void WriteGetType(MemberData[] members)

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
@@ -451,7 +451,8 @@ namespace Dapper.CodeAnalysis
 
                 bool IsDBNull(ITypeSymbol typeSymbol)
                 {
-                    return typeSymbol.ContainingNamespace.Name == "System"
+                    return typeSymbol.ContainingNamespace.ContainingNamespace?.IsGlobalNamespace == true
+                        && typeSymbol.ContainingNamespace.Name == "System"
                         && typeSymbol.Name == "DBNull";
                 }
             }

--- a/src/Dapper.AOT.Analyzers/Internal/Roslyn/TypeSymbolExtensions.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Roslyn/TypeSymbolExtensions.cs
@@ -59,6 +59,24 @@ internal static class TypeSymbolExtensions
         };
     }
 
+    public static bool IsNullable(this ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol.NullableAnnotation == NullableAnnotation.Annotated) return true;
+        return typeSymbol.TypeKind is 
+            TypeKind.Class or TypeKind.Array or
+            TypeKind.Delegate or TypeKind.Dynamic or
+            TypeKind.Interface;
+    }
+
+    /// <returns>
+    /// Returns true, if <paramref name="typeSymbol"/> represents an <see cref="object"/> type.
+    /// </returns>
+    public static bool IsSystemObject(this ITypeSymbol? typeSymbol)
+    {
+        if (typeSymbol is null) return false;
+        return typeSymbol.SpecialType == SpecialType.System_Object;
+    }
+
     /// <returns>
     /// True, if passed <param name="typeSymbol"/> represents array. False otherwise
     /// </returns>

--- a/test/Dapper.AOT.Test/Accessors/Data/Accessor.input.cs
+++ b/test/Dapper.AOT.Test/Accessors/Data/Accessor.input.cs
@@ -1,4 +1,5 @@
-﻿using Dapper;
+﻿using System;
+using Dapper;
 
 [module: DapperAot]
 
@@ -20,6 +21,7 @@ public static class Foo
         public double? Z { get; set; }
         public State State { get; set; }
         public object Obj { get; set; }
+        public DBNull DbNullProp { get; set; }
     }
     public enum State
     {

--- a/test/Dapper.AOT.Test/Accessors/Data/Accessor.input.cs
+++ b/test/Dapper.AOT.Test/Accessors/Data/Accessor.input.cs
@@ -19,6 +19,7 @@ public static class Foo
         public string Y;
         public double? Z { get; set; }
         public State State { get; set; }
+        public object Obj { get; set; }
     }
     public enum State
     {

--- a/test/Dapper.AOT.Test/Accessors/Data/Accessor.output.cs
+++ b/test/Dapper.AOT.Test/Accessors/Data/Accessor.output.cs
@@ -12,7 +12,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
     private sealed class DapperCustomTypeAccessor0 : global::Dapper.TypeAccessor<global::Foo.Customer>
     {
         internal static readonly DapperCustomTypeAccessor0 Instance = new();
-        public override int MemberCount => 4;
+        public override int MemberCount => 5;
         public override int? TryIndex(string name, bool exact = false)
         {
             if (exact)
@@ -23,6 +23,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     nameof(global::Foo.Customer.Y) => 1,
                     nameof(global::Foo.Customer.Z) => 2,
                     nameof(global::Foo.Customer.State) => 3,
+                    nameof(global::Foo.Customer.Obj) => 4,
                     _ => base.TryIndex(name, exact)
                 };
             }
@@ -34,6 +35,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     4228665076U when NormalizedEquals(name, "y") => 1,
                     4278997933U when NormalizedEquals(name, "z") => 2,
                     2016490230U when NormalizedEquals(name, "state") => 3,
+                    3343205242U when NormalizedEquals(name, "obj") => 4,
                     _ => base.TryIndex(name, exact)
                 };
             }
@@ -44,6 +46,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             1 => nameof(global::Foo.Customer.Y),
             2 => nameof(global::Foo.Customer.Z),
             3 => nameof(global::Foo.Customer.State),
+            4 => nameof(global::Foo.Customer.Obj),
             _ => base.GetName(index)
         };
         public override object? this[global::Foo.Customer obj, int index]
@@ -54,6 +57,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
                 1 => obj.Y,
                 2 => obj.Z,
                 3 => obj.State,
+                4 => obj.Obj,
                 _ => base[obj, index]
             };
             set
@@ -64,15 +68,23 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     case 1: obj.Y = (string)value!; break;
                     case 2: obj.Z = (double?)value!; break;
                     case 3: obj.State = (Foo.State)value!; break;
+                    case 4: obj.Obj = (object)value!; break;
                     default: base[obj, index] = value; break;
                 };
             }
         }
         public override bool IsNullable(int index) => index switch
         {
-            2 => true,
+            2 or 4 => true,
             0 or 1 or 3 => false,
             _ => base.IsNullable(index)
+        };
+        public override bool IsNull(global::Foo.Customer obj, int index) => index switch
+        {
+            0 or 1 or 3 => false,
+            2 => obj.Z is null,
+            4 => obj.Obj is null or global::System.DBNull,
+            _ => base.IsNull(obj, index)
         };
         public override global::System.Type GetType(int index) => index switch
         {
@@ -80,6 +92,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             1 => typeof(string),
             2 => typeof(double?),
             3 => typeof(Foo.State),
+            4 => typeof(object),
             _ => base.GetType(index)
         };
         public override TValue GetValue<TValue>(global::Foo.Customer obj, int index) => index switch
@@ -88,6 +101,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             1 when typeof(TValue) == typeof(string) => UnsafePun<string, TValue>(obj.Y),
             2 when typeof(TValue) == typeof(double?) => UnsafePun<double?, TValue>(obj.Z),
             3 when typeof(TValue) == typeof(Foo.State) || typeof(TValue) == typeof(int) => UnsafePun<Foo.State, TValue>(obj.State),
+            4 when typeof(TValue) == typeof(object) => UnsafePun<object, TValue>(obj.Obj),
             _ => base.GetValue<TValue>(obj, index)
         };
         public override void SetValue<TValue>(global::Foo.Customer obj, int index, TValue value)
@@ -105,6 +119,9 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     break;
                 case 3 when typeof(TValue) == typeof(Foo.State) || typeof(TValue) == typeof(int):
                     obj.State = UnsafePun<TValue, Foo.State>(value);
+                    break;
+                case 4 when typeof(TValue) == typeof(object):
+                    obj.Obj = UnsafePun<TValue, object>(value);
                     break;
 
             }

--- a/test/Dapper.AOT.Test/Accessors/Data/Accessor.output.cs
+++ b/test/Dapper.AOT.Test/Accessors/Data/Accessor.output.cs
@@ -1,18 +1,18 @@
 #nullable enable
 file static class DapperTypeAccessorGeneratedInterceptors
 {
-    [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Accessors\\Data\\Accessor.input.cs", 10, 26)]
+    [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Accessors\\Data\\Accessor.input.cs", 11, 26)]
     internal static global::Dapper.ObjectAccessor<global::Foo.Customer> Forwarded0(global::Foo.Customer obj, global::Dapper.TypeAccessor<global::Foo.Customer>? accessor)
         => global::Dapper.TypeAccessor.CreateAccessor(obj, accessor ?? DapperCustomTypeAccessor0.Instance);
 
-    [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Accessors\\Data\\Accessor.input.cs", 13, 26)]
+    [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Accessors\\Data\\Accessor.input.cs", 14, 26)]
     internal static global::System.Data.Common.DbDataReader Forwarded1(global::System.Collections.Generic.IEnumerable<global::Foo.Customer> source, string[]? members, bool exact, global::Dapper.TypeAccessor<global::Foo.Customer>? accessor)
         => global::Dapper.TypeAccessor.CreateDataReader(source, members, exact, accessor ?? DapperCustomTypeAccessor0.Instance);
 
     private sealed class DapperCustomTypeAccessor0 : global::Dapper.TypeAccessor<global::Foo.Customer>
     {
         internal static readonly DapperCustomTypeAccessor0 Instance = new();
-        public override int MemberCount => 5;
+        public override int MemberCount => 6;
         public override int? TryIndex(string name, bool exact = false)
         {
             if (exact)
@@ -24,6 +24,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     nameof(global::Foo.Customer.Z) => 2,
                     nameof(global::Foo.Customer.State) => 3,
                     nameof(global::Foo.Customer.Obj) => 4,
+                    nameof(global::Foo.Customer.DbNullProp) => 5,
                     _ => base.TryIndex(name, exact)
                 };
             }
@@ -36,6 +37,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     4278997933U when NormalizedEquals(name, "z") => 2,
                     2016490230U when NormalizedEquals(name, "state") => 3,
                     3343205242U when NormalizedEquals(name, "obj") => 4,
+                    492569847U when NormalizedEquals(name, "dbnullprop") => 5,
                     _ => base.TryIndex(name, exact)
                 };
             }
@@ -47,6 +49,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             2 => nameof(global::Foo.Customer.Z),
             3 => nameof(global::Foo.Customer.State),
             4 => nameof(global::Foo.Customer.Obj),
+            5 => nameof(global::Foo.Customer.DbNullProp),
             _ => base.GetName(index)
         };
         public override object? this[global::Foo.Customer obj, int index]
@@ -58,6 +61,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
                 2 => obj.Z,
                 3 => obj.State,
                 4 => obj.Obj,
+                5 => obj.DbNullProp,
                 _ => base[obj, index]
             };
             set
@@ -69,13 +73,14 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     case 2: obj.Z = (double?)value!; break;
                     case 3: obj.State = (Foo.State)value!; break;
                     case 4: obj.Obj = (object)value!; break;
+                    case 5: obj.DbNullProp = (System.DBNull)value!; break;
                     default: base[obj, index] = value; break;
                 };
             }
         }
         public override bool IsNullable(int index) => index switch
         {
-            2 or 4 => true,
+            2 or 4 or 5 => true,
             0 or 1 or 3 => false,
             _ => base.IsNullable(index)
         };
@@ -84,6 +89,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             0 or 1 or 3 => false,
             2 => obj.Z is null,
             4 => obj.Obj is null or global::System.DBNull,
+            5 => true,
             _ => base.IsNull(obj, index)
         };
         public override global::System.Type GetType(int index) => index switch
@@ -93,6 +99,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             2 => typeof(double?),
             3 => typeof(Foo.State),
             4 => typeof(object),
+            5 => typeof(System.DBNull),
             _ => base.GetType(index)
         };
         public override TValue GetValue<TValue>(global::Foo.Customer obj, int index) => index switch
@@ -102,6 +109,7 @@ file static class DapperTypeAccessorGeneratedInterceptors
             2 when typeof(TValue) == typeof(double?) => UnsafePun<double?, TValue>(obj.Z),
             3 when typeof(TValue) == typeof(Foo.State) || typeof(TValue) == typeof(int) => UnsafePun<Foo.State, TValue>(obj.State),
             4 when typeof(TValue) == typeof(object) => UnsafePun<object, TValue>(obj.Obj),
+            5 when typeof(TValue) == typeof(System.DBNull) => UnsafePun<System.DBNull, TValue>(obj.DbNullProp),
             _ => base.GetValue<TValue>(obj, index)
         };
         public override void SetValue<TValue>(global::Foo.Customer obj, int index, TValue value)
@@ -122,6 +130,9 @@ file static class DapperTypeAccessorGeneratedInterceptors
                     break;
                 case 4 when typeof(TValue) == typeof(object):
                     obj.Obj = UnsafePun<TValue, object>(value);
+                    break;
+                case 5 when typeof(TValue) == typeof(System.DBNull):
+                    obj.DbNullProp = UnsafePun<TValue, System.DBNull>(value);
                     break;
 
             }

--- a/test/Dapper.AOT.Test/Internal/Roslyn/TypeSymbolExtensionTests.cs
+++ b/test/Dapper.AOT.Test/Internal/Roslyn/TypeSymbolExtensionTests.cs
@@ -10,6 +10,20 @@ namespace Dapper.Internal.Roslyn
     public class TypeSymbolExtensionsTests
     {
         [Fact]
+        public void CheckSystemObject()
+        {
+            var text = BuildDapperCodeText(
+            """
+            _ = connection.Execute("def", new Customer());
+            """);
+
+            var argumentOperation = GetInvocationArgumentOperation(text);
+            var typeSymbol = GetConversionTypeSymbol(argumentOperation);
+
+            Assert.True(typeSymbol.IsNullable());
+        }
+
+        [Fact]
         public void CheckCollectionType_TwoDimensionalArray()
         {
             var text = BuildDapperCodeText(


### PR DESCRIPTION
expected implementation:
```
public override bool IsNull(T obj, int index) => index switch {
    1 or 2 or 6 => false, // non-nullable value-type
    3 => obj.Name is null, // known reference-type
    4 => obj.DateOfBirth is null, // nullable value-type
    5 => obj.Token is null or DBNull, // object : consider null and the special DBNull
    7 => true, // known to be DBNull ... so: can only ever be null or DbNull, so: always null!
    _ => throw...
}
```