### PR TITLE
feat: warn about ambiguous properties/fields

### DIFF
--- a/docs/rules/DAP046.md
+++ b/docs/rules/DAP046.md
@@ -1,0 +1,24 @@
+﻿# DAP046
+
+Dapper uses normalization for the type properties, and this can cause problems when the properties are not unique.
+Recomendation is to use a uniquelly normalized name for each property, which would not conflict with other normalized properties names.
+
+Bad:
+
+``` c#
+public class MyType
+{
+	public string First_Name { get; set; }
+    public string FirstName { get; set; }
+}
+```
+
+Good:
+
+``` c#
+public class MyType
+{
+	public string FirstName { get; set; }
+    public string FirstNaming { get; set; }
+}
+```

--- a/docs/rules/DAP046.md
+++ b/docs/rules/DAP046.md
@@ -8,7 +8,7 @@ Bad:
 ``` c#
 public class MyType
 {
-	public string First_Name { get; set; }
+    public string First_Name { get; set; }
     public string FirstName { get; set; }
 }
 ```
@@ -18,7 +18,7 @@ Good:
 ``` c#
 public class MyType
 {
-	public string FirstName { get; set; }
+    public string FirstName { get; set; }
     public string FirstNaming { get; set; }
 }
 ```

--- a/docs/rules/DAP047.md
+++ b/docs/rules/DAP047.md
@@ -1,0 +1,24 @@
+﻿# DAP047
+
+Dapper uses normalization for the type fields, and this can cause problems when the fields are not unique.
+Recomendation is to use a uniquelly normalized name for each field, which would not conflict with other normalized fields names.
+
+Bad:
+
+``` c#
+public class MyType
+{
+	public string _firstName;
+    public string first_name;
+}
+```
+
+Good:
+
+``` c#
+public class MyType
+{
+	public string firstName;
+    public string firstNaming;
+}
+```

--- a/docs/rules/DAP047.md
+++ b/docs/rules/DAP047.md
@@ -8,7 +8,7 @@ Bad:
 ``` c#
 public class MyType
 {
-	public string _firstName;
+    public string _firstName;
     public string first_name;
 }
 ```
@@ -18,7 +18,7 @@ Good:
 ``` c#
 public class MyType
 {
-	public string firstName;
+    public string firstName;
     public string firstNaming;
 }
 ```

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.Diagnostics.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.Diagnostics.cs
@@ -53,6 +53,8 @@ partial class DapperAnalyzer
         UseColumnAttributeNotSpecified = LibraryWarning("DAP043", "[Column] has no effect", "Attach the [UseColumnAttribute] attribute to make Dapper consider [Column]"),
         CancellationNotSupported = LibraryWarning("DAP044", "Cancellation not supported", "Vanilla Dapper does not support cancellation parameters in this scenario"),
         CancellationDuplicated = LibraryWarning("DAP045", "Duplicate cancellation", "Multiple parameter values cannot define cancellation"),
+        AmbiguousProperties = LibraryWarning("DAP046", "Ambiguous properties", "Properties have same name '{0}' after normalization and can be conflated"),
+        AmbiguousFields = LibraryWarning("DAP047", "Ambiguous fields", "Fields have same name '{0}' after normalization and can be conflated"),
 
         // SQL parse specific
         GeneralSqlError = SqlWarning("DAP200", "SQL error", "SQL error: {0}"),

--- a/test/Dapper.AOT.Test/Verifiers/DAP021.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP021.cs
@@ -18,11 +18,10 @@ public class DAP021 : Verifier<DapperAnalyzer>
             void SomeMethod(DbConnection conn)
                 => conn.Execute("someproc", this);
 
-            {|#1:public int Id {get;set;}|}
+            public int {|#1:Id|} {get;set;}
 
             [{|#0:DbValue(Name = "Id")|}] // location should prefer the attrib when exists; dup is primary
             public int OtherId {get;set;}
-
 
             [{|#3:DbValue(Name = "X")|}]
             public int Y {get;set;}
@@ -30,8 +29,8 @@ public class DAP021 : Verifier<DapperAnalyzer>
             [{|#2:DbValue(Name = "X")|}] // dup is primary
             public int Z {get;set;}
 
-            {|#5:public int casing {get;set;}|}
-            {|#4:public int CASING {get;set;}|} // dup is primary
+            public int {|#5:casing|} {get;set;}
+            public int {|#4:CASING|} {get;set;} // dup is primary
 
             public int fixedCase {get;set;}
             [DbValue(Name = "AnotherName")]

--- a/test/Dapper.AOT.Test/Verifiers/DAP045.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP045.cs
@@ -21,7 +21,7 @@ public class DAP045 : Verifier<DapperAnalyzer>
             {
                 _ = conn.ExecuteAsync("some_proc", cancellationToken);
                 _ = conn.ExecuteAsync("some_proc", new { id, x = cancellationToken });
-                _ = conn.ExecuteAsync("some_proc", new { id, x = cancellationToken, {|#0:y = cancellationToken|}});
+                _ = conn.ExecuteAsync("some_proc", new { id, x = cancellationToken, {|#0:y|} = cancellationToken});
             }
         }
         """,

--- a/test/Dapper.AOT.Test/Verifiers/DAP046.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP046.cs
@@ -1,0 +1,43 @@
+﻿using Dapper.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+using static Dapper.CodeAnalysis.DapperAnalyzer;
+
+namespace Dapper.AOT.Test.Verifiers;
+
+public class DAP046 : Verifier<DapperAnalyzer>
+{
+    [Theory]
+    [InlineData("[DapperAot(true)]")]
+    [InlineData("[DapperAot(false)]")]
+    public Task AmbiguousProperties(string dapperAotAttribute) => CSVerifyAsync($$"""
+        using Dapper;
+        using System.Data.Common;
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        public class Data
+        {
+            public string firstName; // THIS IS FINE AND SHOULD NOT REPORT DIAGNOSTIC -> IT IS A FIELD,
+
+            public string {|#0:First_Name|} { get; set; }
+            public string {|#1:FirstName|} { get; set; }
+        }
+
+        {{dapperAotAttribute}}
+        class WithoutAot
+        {
+            public void DapperCode(DbConnection conn)
+            {
+                _ = conn.Query<Data>("select_proc");
+            }
+        }
+        """,
+        DefaultConfig,
+        [
+            Diagnostic(Diagnostics.AmbiguousProperties)
+                .WithArguments("firstname")
+                .WithLocation(0).WithLocation(1)
+        ]
+    );
+}

--- a/test/Dapper.AOT.Test/Verifiers/DAP047.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP047.cs
@@ -1,0 +1,43 @@
+﻿using Dapper.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+using static Dapper.CodeAnalysis.DapperAnalyzer;
+
+namespace Dapper.AOT.Test.Verifiers;
+
+public class DAP047 : Verifier<DapperAnalyzer>
+{
+    [Theory]
+    [InlineData("[DapperAot(true)]")]
+    [InlineData("[DapperAot(false)]")]
+    public Task AmbiguousFields(string dapperAotAttribute) => CSVerifyAsync($$"""
+        using Dapper;
+        using System.Data.Common;
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        public class Data
+        {
+            public string FirstName { get; set; } // THIS IS FINE AND SHOULD NOT REPORT DIAGNOSTIC -> IT IS A PROPERTY,
+
+            public string {|#0:first_name|};
+            public string {|#1:_firstName|};
+        }
+
+        {{dapperAotAttribute}}
+        class WithoutAot
+        {
+            public void DapperCode(DbConnection conn)
+            {
+                _ = conn.Query<Data>("select_proc");
+            }
+        }
+        """,
+        DefaultConfig,
+        [
+            Diagnostic(Diagnostics.AmbiguousFields)
+                .WithArguments("firstname")
+                .WithLocation(0).WithLocation(1)
+        ]
+    );
+}


### PR DESCRIPTION
_Original issue:_ https://github.com/DapperLib/Dapper/issues/1993

added the rules:
1) if properties of type have same normalized names -> `DAP046` is reported:
`Properties have same name '{normalizedMemberName}' after normalization and can be conflated`
example:
```csharp
public class Data
{
    public string First_Name { get; set; }
    public string FirstName { get; set; }
}
```

2) if fields of type have same normalized names -> `DAP047` is reported:
`Fields have same name '{normalizedMemberName}' after normalization and can be conflated`
```csharp
public class Data
{
    public string first_name;
    public string _firstName;
}
```

**Note**: I changed the locations calculations reported for properties. 
For `ElementMember` representing `public string Name { get; set; }` property, calling `member.GetLocation()` will return `Span`, wrapping the whole property definition (including modifiers, getter and setter).

I thought that standard way of reporting errors is to link the diagnostic with the _member name_. For example (not related to Dapper) - duplicate property names of type:
![image](https://github.com/DapperLib/DapperAOT/assets/31598696/6340e7c8-d7ac-40a7-9c54-b9558f2918b5)

So I decided to bring such a consistency to the diagnostics. Also fields are reported only on the names (not the full field definition). Let me know if that change should be reverted


Closes #65