### PR TITLE
fix: dont report DAP037 on array types

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -192,8 +192,8 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
 
             // check the types
             // resultType can be an array, so let's unwrap it to determine actual type
-            var resultType = invoke.GetResultType(flags)?.UnwrapArrayType();
-            if (resultType is not null && IdentifyDbType(resultType, out _) is null) // don't warn if handled as an inbuilt
+            var resultType = invoke.GetResultType(flags);
+            if (resultType is not null && IdentifyDbType(resultType, out _) is null && !IsSpecialCaseAllowedResultType(resultType)) // don't warn if handled as an inbuilt
             {
                 var resultMap = MemberMap.CreateForResults(resultType, location);
                 if (resultMap is not null)

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -191,7 +191,8 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
             }
 
             // check the types
-            var resultType = invoke.GetResultType(flags);
+            // resultType can be an array, so let's unwrap it to determine actual type
+            var resultType = invoke.GetResultType(flags)?.UnwrapArrayType();
             if (resultType is not null && IdentifyDbType(resultType, out _) is null) // don't warn if handled as an inbuilt
             {
                 var resultMap = MemberMap.CreateForResults(resultType, location);

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -1208,6 +1208,24 @@ internal static class Inspection
     public static bool TryGetConstantValue<T>(IOperation op, out T? value)
             => TryGetConstantValueWithSyntax(op, out value, out _, out _);
 
+    public static ITypeSymbol? UnwrapArrayType(this ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol is not IArrayTypeSymbol arrayTypeSymbol)
+        {
+            return typeSymbol;
+        }
+
+        ITypeSymbol elementType;
+        IArrayTypeSymbol? currentArraySymbol = arrayTypeSymbol;
+        do
+        {
+            elementType = currentArraySymbol.ElementType;
+            currentArraySymbol = elementType as IArrayTypeSymbol;
+        } while (currentArraySymbol is not null);
+
+        return elementType;
+    }
+    
     public static ITypeSymbol? GetResultType(this IInvocationOperation invocation, OperationFlags flags)
     {
         if (flags.HasAny(OperationFlags.TypedResult))

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -505,7 +505,7 @@ internal static class Inspection
                     ContainingNamespace:
                     {
                         Name: "Dapper",
-                        IsGlobalNamespace: true
+                        ContainingNamespace.IsGlobalNamespace: true
                     }
                 }) return DapperSpecialType.DbString;
                 

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -1058,6 +1058,21 @@ internal static class Inspection
             ? type : type.WithNullableAnnotation(NullableAnnotation.None);
     }
 
+    /// <summary>
+    /// There are special types we are allowing user to query,
+    /// which are not handled in the general checks
+    /// </summary>
+    public static bool IsSpecialCaseAllowedResultType(ITypeSymbol? type)
+    {
+        // byte[] or sbyte[] are basically blobs
+        if (type is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_Byte or SpecialType.System_SByte })
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     public static DbType? IdentifyDbType(ITypeSymbol? type, out string? readerMethod)
     {
         if (type is null)
@@ -1207,24 +1222,6 @@ internal static class Inspection
 
     public static bool TryGetConstantValue<T>(IOperation op, out T? value)
             => TryGetConstantValueWithSyntax(op, out value, out _, out _);
-
-    public static ITypeSymbol? UnwrapArrayType(this ITypeSymbol typeSymbol)
-    {
-        if (typeSymbol is not IArrayTypeSymbol arrayTypeSymbol)
-        {
-            return typeSymbol;
-        }
-
-        ITypeSymbol elementType;
-        IArrayTypeSymbol? currentArraySymbol = arrayTypeSymbol;
-        do
-        {
-            elementType = currentArraySymbol.ElementType;
-            currentArraySymbol = elementType as IArrayTypeSymbol;
-        } while (currentArraySymbol is not null);
-
-        return elementType;
-    }
     
     public static ITypeSymbol? GetResultType(this IInvocationOperation invocation, OperationFlags flags)
     {

--- a/test/Dapper.AOT.Test/Verifiers/DAP037.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP037.cs
@@ -10,6 +10,7 @@ public class DAP037 : Verifier<DapperAnalyzer>
     [Fact]
     public Task UserTypeNoSettableMembersFound() => CSVerifyAsync(""""
         using Dapper;
+        using System.Collections.Generic;
         using System.Data.Common;
         using System.Runtime.Serialization;
 
@@ -33,6 +34,11 @@ public class DAP037 : Verifier<DapperAnalyzer>
                 _ = conn.{|#1:Query<ReadOnlyField>|}(sql, args);
                 _ = conn.Query<HazImplicitConstructor>(sql, args);
                 _ = conn.Query<HazExplicitConstructor>(sql, args);
+                _ = conn.Query<sbyte[]>(sql, args);
+                _ = conn.Query<byte[]>(sql, args);
+                _ = conn.Query<byte[][]>(sql, args);
+                _ = conn.Query<byte[][][]>(sql, args);
+                _ = conn.Query<int>(sql, args);
             }
         }
 

--- a/test/Dapper.AOT.Test/Verifiers/DAP037.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP037.cs
@@ -36,9 +36,7 @@ public class DAP037 : Verifier<DapperAnalyzer>
                 _ = conn.Query<HazExplicitConstructor>(sql, args);
                 _ = conn.Query<sbyte[]>(sql, args);
                 _ = conn.Query<byte[]>(sql, args);
-                _ = conn.Query<byte[][]>(sql, args);
-                _ = conn.Query<byte[][][]>(sql, args);
-                _ = conn.Query<int>(sql, args);
+                _ = conn.{|#2:Query<int[]>|}(sql, args);
             }
         }
 
@@ -82,6 +80,7 @@ public class DAP037 : Verifier<DapperAnalyzer>
         """", DefaultConfig, [
             Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(0).WithArguments("NoSettable"),
             Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(1).WithArguments("ReadOnlyField"),
+            Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(2).WithArguments(""),
     ]);
 
 }


### PR DESCRIPTION
I believe this is a correct usage of where result type is either `userType[]` or `primitiveType[]`.
```
await conn.Query<byte[]>(...)
```
We should not report the [DAP037](https://github.com/DapperLib/DapperAOT/blob/main/docs/rules/DAP037.md), because lets say `byte[]` does not have accessible fields\properties, but it is valid expected result type.

Closes #123