### PR TITLE
feat: support DbCommand command-text via constructor string sql query parse

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -346,7 +346,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        private void ValidateParameterUsage(in OperationAnalysisContext ctx, IOperation sqlSource, IOperation sqlUsage = null)
+        private void ValidateParameterUsage(in OperationAnalysisContext ctx, IOperation sqlSource, IOperation? sqlUsage = null)
         {
             // TODO: check other parameters for special markers like command type?
             var flags = SqlParseInputFlags.None;
@@ -391,7 +391,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
         }
 
         private void ValidateSql(in OperationAnalysisContext ctx, IOperation sqlSource, SqlParseInputFlags flags,
-            ImmutableArray<SqlParameter> parameters, Location? location = null, IOperation sqlUsageOperation = null)
+            ImmutableArray<SqlParameter> parameters, Location? location = null, IOperation? sqlUsageOperation = null)
         {
             var parseState = new ParseState(ctx);
 

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -146,6 +146,24 @@ internal static class Inspection
         return false;
     }
 
+    public static bool IsSqlClient(ITypeSymbol? typeSymbol) => typeSymbol is
+    {
+        Name: "SqlCommand",
+        ContainingNamespace:
+        {
+            Name: "SqlClient",
+            ContainingNamespace:
+            {
+                Name: "Data",
+                ContainingNamespace:
+                {
+                    Name: "Microsoft" or "System", // either Microsoft.Data.SqlClient or System.Data.SqlClient
+                    ContainingNamespace.IsGlobalNamespace: true
+                }
+            }
+        }
+    };
+
     public static bool IsDapperAttribute(AttributeData attrib)
         => attrib.AttributeClass is
         {

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -1432,6 +1432,26 @@ internal static class Inspection
                 }
             }
         }
+        else if (op is IObjectCreationOperation objectCreationOp)
+        {
+            var ctorTypeNamespace = objectCreationOp.Type?.ContainingNamespace;
+            var ctorTypeName = objectCreationOp.Type?.Name;
+
+            if (ctorTypeNamespace is not null && ctorTypeName is not null)
+            {
+                foreach (var candidate in KnownConnectionTypes)
+                {
+                    var current = ctorTypeNamespace;
+                    if (ctorTypeName == candidate.Command
+                        && AssertAndAscend(ref current, candidate.Namespace0)
+                        && AssertAndAscend(ref current, candidate.Namespace1)
+                        && AssertAndAscend(ref current, candidate.Namespace2))
+                    {
+                        return candidate.Syntax;
+                    }
+                }
+            }
+        }
 
         return null;
 

--- a/src/Dapper.AOT.Analyzers/Internal/Roslyn/LanguageHelper.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Roslyn/LanguageHelper.cs
@@ -110,7 +110,7 @@ internal abstract partial class LanguageHelper
 
     internal virtual StringSyntaxKind? TryDetectOperationStringSyntaxKind(IOperation operation)
     {
-        if (operation is null) return null;
+        if (operation is null || operation is ILiteralOperation) return null;
         if (operation is IBinaryOperation)
         {
             return StringSyntaxKind.ConcatenatedString;

--- a/test/Dapper.AOT.Test/Verifiers/SqlDetection.cs
+++ b/test/Dapper.AOT.Test/Verifiers/SqlDetection.cs
@@ -185,31 +185,31 @@ public class SqlDetection : Verifier<DapperAnalyzer>
             static void Main()
             {
                 using var conn = new SqlConnection("my connection string here");
-        string name = "abc";
-        conn.{|#0:Execute|}("""
-            select Id, Name, Age
-            from Users
-            where Id = @id
-            and Name = @name
-            and Age = @age
-            and Something = {|#1:null|}
-            """, new
-        {
-            name,
-            id = 42,
-            age = 24,
-        });
+                string name = "abc";
+                conn.{|#0:Execute|}("""
+                    select Id, Name, Age
+                    from Users
+                    where Id = @id
+                    and Name = @name
+                    and Age = @age
+                    and Something = {|#1:null|}
+                    """, new
+                {
+                    name,
+                    id = 42,
+                    age = 24,
+                });
 
-        using var cmd = new SqlCommand("should {|#3:|}' verify this too", conn);
-        cmd.CommandText = """
-            select Id, Name, Age
-            from Users
-            where Id = @id
-            and Name = @name
-            and Age = @age
-            and Something = {|#2:null|}
-            """;
-        cmd.ExecuteNonQuery();
+                using var cmd = new SqlCommand("should {|#3:|}' verify this too", conn);
+                cmd.CommandText = """
+                    select Id, Name, Age
+                    from Users
+                    where Id = @id
+                    and Name = @name
+                    and Age = @age
+                    and Something = {|#2:null|}
+                    """;
+                cmd.ExecuteNonQuery();
             }
         }
 """", [], [

--- a/test/Dapper.AOT.Test/Verifiers/SqlDetection.cs
+++ b/test/Dapper.AOT.Test/Verifiers/SqlDetection.cs
@@ -276,7 +276,7 @@ public class SqlDetection : Verifier<DapperAnalyzer>
             and Age = @age
             and Something = {|#1:null|}", New With {name, .id = 42, .age = 24 })
 
-                    Using cmd As New SqlCommand("should ' verify this too", conn)
+                    Using cmd As New SqlCommand("should {|#3:|}' verify this too", conn)
                         cmd.CommandText = "
             select Id, Name, Age
             from Users
@@ -292,6 +292,7 @@ public class SqlDetection : Verifier<DapperAnalyzer>
 """, [], [
         Diagnostic(DapperAnalyzer.Diagnostics.ExecuteCommandWithQuery).WithLocation(0),
         Diagnostic(DapperAnalyzer.Diagnostics.NullLiteralComparison).WithLocation(1),
-        Diagnostic(DapperAnalyzer.Diagnostics.NullLiteralComparison).WithLocation(2)
+        Diagnostic(DapperAnalyzer.Diagnostics.NullLiteralComparison).WithLocation(2),
+        Diagnostic(DapperAnalyzer.Diagnostics.ParseError).WithLocation(3).WithArguments(46030, "Expected but did not find a closing quotation mark after the character string ' verify this too.")
     ], SqlSyntax.General, refDapperAot: false);
 }

--- a/test/Dapper.AOT.Test/Verifiers/SqlDetection.cs
+++ b/test/Dapper.AOT.Test/Verifiers/SqlDetection.cs
@@ -184,7 +184,7 @@ public class SqlDetection : Verifier<DapperAnalyzer>
         {
             static void Main()
             {
-        using var conn = new SqlConnection("my connection string here");
+                using var conn = new SqlConnection("my connection string here");
         string name = "abc";
         conn.{|#0:Execute|}("""
             select Id, Name, Age
@@ -200,7 +200,7 @@ public class SqlDetection : Verifier<DapperAnalyzer>
             age = 24,
         });
 
-        using var cmd = new SqlCommand("should ' verify this too", conn);
+        using var cmd = new SqlCommand("should {|#3:|}' verify this too", conn);
         cmd.CommandText = """
             select Id, Name, Age
             from Users
@@ -217,6 +217,7 @@ public class SqlDetection : Verifier<DapperAnalyzer>
         Diagnostic(DapperAnalyzer.Diagnostics.ExecuteCommandWithQuery).WithLocation(0),
         Diagnostic(DapperAnalyzer.Diagnostics.NullLiteralComparison).WithLocation(1),
         Diagnostic(DapperAnalyzer.Diagnostics.NullLiteralComparison).WithLocation(2),
+        Diagnostic(DapperAnalyzer.Diagnostics.ParseError).WithLocation(3).WithArguments(46030, "Expected but did not find a closing quotation mark after the character string ' verify this too.")
     ], SqlSyntax.General, refDapperAot: false);
 
     [Fact]


### PR DESCRIPTION
Added support for parsing `Microsoft.Data.SqlClient.SqlCommand(string cmdText)` parameter sql parse and validation against errors

Closes #133 