### PR TITLE
If a record has multiple constructors without an explicit constructor chosen, default to the primary construcor

### DIFF
--- a/test/Dapper.AOT.Test/Verifiers/DAP036.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP036.cs
@@ -23,7 +23,9 @@ public class DAP036 : Verifier<DapperAnalyzer>
                 _ = conn.Query<MultipleImplicit>("storedproc");
 
                 _ = conn.Query<RecordClass>("storedproc");
+                _ = conn.Query<RecordClassWithMultipleConstructors>("storedproc");
                 _ = conn.Query<RecordStruct>("storedproc");
+                _ = conn.Query<RecordStructWithMultipleConstructors>("storedproc");
                 _ = conn.Query<ReadOnlyRecordStruct>("storedproc");
             }
 
@@ -51,7 +53,15 @@ public class DAP036 : Verifier<DapperAnalyzer>
             public MultipleImplicit(MultipleImplicit c) {}
         }
         record class RecordClass(int a);
+        public record class RecordClassWithMultipleConstructors(int a, bool b)
+        {
+            public RecordClassWithMultipleConstructors(int a) : this(a, false) {}
+        }
         record struct RecordStruct(int a);
+        public record struct RecordStructWithMultipleConstructors(int a, bool b)
+        {
+            public RecordStructWithMultipleConstructors(int a) : this(a, false) {}
+        }
         readonly record struct ReadOnlyRecordStruct(int a);
 
         namespace System.Runtime.CompilerServices


### PR DESCRIPTION
The following program will fail with `Error DAP036 : Type 'RecordWithMultipleConstructors' has more than 1 constructor; mark one constructor with [ExplicitConstructor] or reduce constructors (https://aot.dapperlib.dev/rules/DAP036)`
```cs
using Dapper;
using Microsoft.Data.Sqlite;
[module:DapperAot]

await using SqliteConnection connection = GetDbConnection();
IEnumerable<RecordWithMultipleConstructors> results = await connection.QueryAsync<RecordWithMultipleConstructors>("SELECT A, B FROM Test");


public record RecordWithMultipleConstructors(int A, int? B)
{
    public RecordWithMultipleConstructors(int A) : this(A, 22) {}
}
```

However you can't add an attribute targeting Constructor/Method on the primary constructor of a record. 

```cs
[ExplicitConstructor]
public record RecordWithMultipleConstructors(int A, int? B)
{
    public RecordWithMultipleConstructors(int A) : this(A, 22) {}
}
```

This will cause an error at build time `Error CS0592 : Attribute 'ExplicitConstructor' is not valid on this declaration type. It is only valid on 'constructor, method' declarations.`

To fix this, if the type is a record and has multiple implicit constructors - default to the primary constructor. 