### PR TITLE
feat: support Dapper overloads with CommandDefinition

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -516,10 +516,10 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
         IEnumerable<IArgumentOperation> arguments = op.Arguments;
 
         // invocation can be packed into a CommandDefinition
-        if (op.Arguments is { Length: 2 })
+        if (op.Arguments is { Length: >= 2 })
         {
             if (op.Arguments[0].Parameter?.Name == "cnn"
-                && op.Arguments[1].Parameter?.Name == "command" && op.Arguments[1].Parameter?.Type.IsDapperType("CommandDefinition") == true)
+                && op.Arguments[1].Parameter?.Name == "command" && op.Arguments[1].Parameter?.Type.IsCommandDefinition() == true)
             {
                 viaCommandDefinition = true;
 

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -192,7 +192,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
             var parseState = new ParseState(ctx);
             bool aotEnabled = IsEnabled(in parseState, invoke, Types.DapperAotAttribute, out var aotAttribExists);
             if (!aotEnabled) flags |= OperationFlags.DoNotGenerate;
-            var location = SharedParseArgsAndFlags(parseState, invoke, ref flags, out var sql, out var argExpression, onDiagnostic, out _, exitFirstFailure: false);
+            var location = SharedParseArgsAndFlags(parseState, invoke, ref flags, out var sql, out var argExpression, onDiagnostic, out _, exitFirstFailure: false, out var viaCommandDefinition);
 
             // report our AOT readiness
             if (aotEnabled)
@@ -410,7 +410,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
             if (caseSensitive) flags |= SqlParseInputFlags.CaseSensitive;
 
             // can we get the SQL itself?
-            if (!TryGetConstantValueWithSyntax(sqlSource, out string? sql, out var sqlSyntax, out var stringSyntaxKind))
+            if (!TryGetStringConstantValueWithSyntax(sqlSource, out string? sql, out var sqlSyntax, out var stringSyntaxKind))
             {
                 DiagnosticDescriptor? descriptor = stringSyntaxKind switch
                 {
@@ -503,23 +503,60 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
 
     // we want a common understanding of the setup between the analyzer and generator
     internal static Location SharedParseArgsAndFlags(in ParseState ctx, IInvocationOperation op, ref OperationFlags flags, out string? sql,
-        out IOperation? argExpression, Action<Diagnostic>? reportDiagnostic, out ITypeSymbol? resultType, bool exitFirstFailure)
+        out IOperation? argExpression, Action<Diagnostic>? reportDiagnostic, out ITypeSymbol? resultType, bool exitFirstFailure,
+        out bool viaCommandDefinition)
     {
         var callLocation = op.GetMemberLocation();
         argExpression = null;
         sql = null;
         bool? buffered = null;
+        viaCommandDefinition = false;
 
-        // check the args
-        foreach (var arg in op.Arguments)
+        // default is invocation, so simply take arguments
+        IEnumerable<IArgumentOperation> arguments = op.Arguments;
+
+        // invocation can be packed into a CommandDefinition
+        if (op.Arguments is { Length: 2 })
         {
+            if (op.Arguments[0].Parameter?.Name == "cnn"
+                && op.Arguments[1].Parameter?.Name == "command" && op.Arguments[1].Parameter?.Type.IsDapperType("CommandDefinition") == true)
+            {
+                viaCommandDefinition = true;
 
+                // by default buffered CommandDefinition constructor initializes `buffered` as true via CommandFlags
+                // https://github.com/DapperLib/Dapper/blob/5c7143f2e3585d4708294a3b0530a134e18ace86/Dapper/CommandDefinition.cs#L85
+                buffered = true;
+
+                // in-place creation of CommandDefinition like `Query<T>(new CommandDefinition(...))`
+                if (op.Arguments[1].Value is IObjectCreationOperation { Arguments.IsDefaultOrEmpty: false } commandDefinitionCreation )
+                {
+                    arguments = commandDefinitionCreation.Arguments;
+                }
+
+                // ideally here we would want to parse other CommandDefinition cases (i.e. local variable).
+                // but it is complicated, so we can simply rely on passing CommandDefinition's members to the underlying query API
+                // ...
+            }
+        }
+
+        // check the args. Names of the parameters are handling Dapper method parameters + CommandDefinition members
+        foreach (var arg in arguments)
+        {
             switch (arg.Parameter?.Name)
             {
                 case "sql":
-                    if (TryGetConstantValueWithSyntax(arg, out string? s, out _, out _))
+                case "commandText":
+                    if (TryGetStringConstantValueWithSyntax(arg, out string? s, out _, out _))
                     {
                         sql = s;
+                    }
+                    break;
+                case "flags":
+                    {
+                        if (TryGetEnumConstantValueWithSyntax(arg, out int? value))
+                        {
+                            buffered = (value & 1) != 0; // CommandFlags.Buffered = 1
+                        }
                     }
                     break;
                 case "buffered":
@@ -529,6 +566,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                     }
                     break;
                 case "param":
+                case "parameters":
                     if (arg.Value is not IDefaultValueOperation)
                     {
                         var expr = arg.Value;
@@ -555,6 +593,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                 case "length":
                 case "returnNullIfFirstMissing":
                 case "concreteType" when arg.Value is IDefaultValueOperation || (arg.ConstantValue.HasValue && arg.ConstantValue.Value is null):
+                case "cancellationToken":
                     // nothing to do
                     break;
                 case "commandType":
@@ -580,6 +619,17 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                             default: // treat as flexible
                                 reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.UnexpectedCommandType, arg.Syntax.GetLocation()));
                                 break;
+                        }
+                    }
+                    break;
+                case "command":
+                    {
+                        // case for CommandDefinition - we need to check that we detected it correctly before
+                        // and if we did; then don't drop errors - we could not parse SQL / other flags in complex CommandDefinition usages,
+                        // but we can optimistically pass CommandDefinition data to underlying query
+                        if (!viaCommandDefinition)
+                        {
+                            goto default;
                         }
                     }
                     break;

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -378,7 +378,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                 sb
                   .Append("global::System.Diagnostics.Debug.Assert(")
                   .Append(viaCommandDefinition ? "command.Buffered is " : "buffered is ")
-                  .Append((flags & OperationFlags.Buffered) != 0).Append("); ").NewLine();
+                  .Append((flags & OperationFlags.Buffered) != 0).Append(");").NewLine();
             }
 
             if (HasParam(methodParameters, "param") || viaCommandDefinition)

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -104,13 +104,11 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                 return null;
             }
 
-            var location = DapperAnalyzer.SharedParseArgsAndFlags(ctx, op, ref flags, out var sql, out var argExpression, reportDiagnostic: null, out var resultType, exitFirstFailure: true);
+            var location = DapperAnalyzer.SharedParseArgsAndFlags(ctx, op, ref flags, out var sql, out var argExpression, reportDiagnostic: null, out var resultType, exitFirstFailure: true, out var viaCommandDefinition);
             if (flags.HasAny(OperationFlags.DoNotGenerate))
             {
                 return null;
             }
-
-
 
             // additional result-type checks
 
@@ -133,7 +131,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             var additionalState = AdditionalCommandState.Parse(Inspection.GetSymbol(ctx, op), map, null);
 
             Debug.Assert(!flags.HasAny(OperationFlags.DoNotGenerate), "should have already exited");
-            return new SuccessSourceState(location, op.TargetMethod, flags, sql, resultType, argExpression?.Type, parameterMap, additionalState);
+            return new SuccessSourceState(location, op.TargetMethod, flags, sql, resultType, argExpression?.Type, parameterMap, additionalState, viaCommandDefinition);
         }
         catch (Exception ex)
         {
@@ -284,7 +282,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         foreach (var grp in ctx.Nodes.OfType<SuccessSourceState>().Where(x => !x.Flags.HasAny(OperationFlags.DoNotGenerate)).GroupBy(x => x.Group(), CommonComparer.Instance))
         {
             // first, try to resolve the helper method that we're going to use for this
-            var (flags, method, parameterType, parameterMap, _, additionalCommandState) = grp.Key;
+            var (flags, method, parameterType, parameterMap, _, additionalCommandState, viaCommandDefinition) = grp.Key;
             const bool useUnsafe = false;
             int usageCount = 0;
 
@@ -343,39 +341,52 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             var methodParameters = grp.Key.Method.Parameters;
             string? fixedSql = null;
 
-            if (HasParam(methodParameters, "sql"))
+            if (HasParam(methodParameters, "sql") || viaCommandDefinition)
             {
                 if (flags.HasAny(OperationFlags.IncludeLocation))
                 {
                     var origin = grp.Single();
                     fixedSql = origin.Sql; // expect exactly one SQL
-                    sb.Append("global::System.Diagnostics.Debug.Assert(sql == ")
+                    sb.Append("global::System.Diagnostics.Debug.Assert(")
+                        .Append(viaCommandDefinition ? "command.CommandText" : "sql").Append(" == ")
                         .AppendVerbatimLiteral(fixedSql).Append(");").NewLine();
                     var path = origin.Location.GetMappedLineSpan();
                     fixedSql = $"-- {path.Path}#{path.StartLinePosition.Line + 1}\r\n{fixedSql}";
                 }
                 else
                 {
-                    sb.Append("global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));").NewLine();
+                    sb.Append("global::System.Diagnostics.Debug.Assert(")
+                        .Append("!string.IsNullOrWhiteSpace(").Append(viaCommandDefinition ? "command.CommandText" : "sql").Append(")")
+                      .Append(");").NewLine();
                 }
             }
-            if (HasParam(methodParameters, "commandType"))
+            if (HasParam(methodParameters, "commandType") || viaCommandDefinition)
             {
                 if (commandTypeMode != 0)
                 {
-                    sb.Append("global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.")
-                            .Append(commandTypeMode.ToString()).Append(");").NewLine();
+                    sb.Append("global::System.Diagnostics.Debug.Assert(")
+                      .Append("(").Append(viaCommandDefinition ? "command.CommandType" : "commandType")
+                      .Append(" ?? global::Dapper.DapperAotExtensions.GetCommandType(")
+                      .Append(viaCommandDefinition ? "command.CommandText" : "sql")
+                      .Append(")) == global::System.Data.CommandType.")
+                      .Append(commandTypeMode.ToString()).Append(");").NewLine();
                 }
             }
 
-            if (flags.HasAny(OperationFlags.Buffered | OperationFlags.Unbuffered) && HasParam(methodParameters, "buffered"))
+            if (flags.HasAny(OperationFlags.Buffered | OperationFlags.Unbuffered) && HasParam(methodParameters, "buffered") || viaCommandDefinition)
             {
-                sb.Append("global::System.Diagnostics.Debug.Assert(buffered is ").Append((flags & OperationFlags.Buffered) != 0).Append(");").NewLine();
+                sb
+                  .Append("global::System.Diagnostics.Debug.Assert(")
+                  .Append(viaCommandDefinition ? "command.Buffered is " : "buffered is ")
+                  .Append((flags & OperationFlags.Buffered) != 0).Append("); ").NewLine();
             }
 
-            if (HasParam(methodParameters, "param"))
+            if (HasParam(methodParameters, "param") || viaCommandDefinition)
             {
-                sb.Append("global::System.Diagnostics.Debug.Assert(param is ").Append(flags.HasAny(OperationFlags.HasParameters) ? "not " : "").Append("null);").NewLine();
+                sb
+                  .Append("global::System.Diagnostics.Debug.Assert(")
+                  .Append(viaCommandDefinition ? "command.Parameters" : "param")
+                  .Append(" is ").Append(flags.HasAny(OperationFlags.HasParameters) ? "not " : "").Append("null);").NewLine();
             }
 
             if (HasParam(methodParameters, "concreteType"))
@@ -398,7 +409,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             }
             else if (!TryWriteMultiExecImplementation(sb, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, fixedSql, additionalCommandState))
             {
-                WriteSingleImplementation(sb, method, resultType, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, readers, fixedSql, additionalCommandState);
+                WriteSingleImplementation(sb, method, resultType, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, readers, fixedSql, additionalCommandState, viaCommandDefinition);
             }
 
             sb.Outdent().NewLine().NewLine();
@@ -1513,10 +1524,12 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         public ITypeSymbol? ResultType { get; }
         public ITypeSymbol? ParameterType { get; }
         public AdditionalCommandState? AdditionalCommandState { get; }
+        public bool ViaCommandDefinition { get; }
 
         public SuccessSourceState(Location location, IMethodSymbol method, OperationFlags flags, string? sql,
             ITypeSymbol? resultType, ITypeSymbol? parameterType, string parameterMap,
-            AdditionalCommandState? additionalCommandState) : base(location)
+            AdditionalCommandState? additionalCommandState,
+            bool viaCommandDefinition) : base(location)
         {
             Flags = flags;
             Sql = sql;
@@ -1525,27 +1538,29 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             Method = method;
             ParameterMap = parameterMap;
             AdditionalCommandState = additionalCommandState;
+            ViaCommandDefinition = viaCommandDefinition;
         }
 
-        public (OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState) Group()
-            => new(Flags, Method, ParameterType, ParameterMap, (Flags & (OperationFlags.CacheCommand | OperationFlags.IncludeLocation)) == 0 ? null : Location, AdditionalCommandState);
+        public (OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState, bool ViaCommandDefinition) Group()
+            => new(Flags, Method, ParameterType, ParameterMap, (Flags & (OperationFlags.CacheCommand | OperationFlags.IncludeLocation)) == 0 ? null : Location, AdditionalCommandState, ViaCommandDefinition);
     }
-    private sealed class CommonComparer : LocationComparer, IEqualityComparer<(OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState)>
+    private sealed class CommonComparer : LocationComparer, IEqualityComparer<(OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState, bool ViaCommandDefinition)>
     {
         public static readonly CommonComparer Instance = new();
         private CommonComparer() { }
 
         public bool Equals(
 
-            (OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState) x,
-            (OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState) y) => x.Flags == y.Flags
+            (OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState, bool ViaCommandDefinition) x,
+            (OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState, bool ViaCommandDefinition) y) => x.Flags == y.Flags
                 && x.ParameterMap == y.ParameterMap
                 && SymbolEqualityComparer.Default.Equals(x.Method, y.Method)
                 && SymbolEqualityComparer.Default.Equals(x.ParameterType, y.ParameterType)
                 && x.UniqueLocation == y.UniqueLocation
-                && Equals(x.AdditionalCommandState, y.AdditionalCommandState);
+                && Equals(x.AdditionalCommandState, y.AdditionalCommandState)
+                && x.ViaCommandDefinition == y.ViaCommandDefinition;
 
-        public int GetHashCode((OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState) obj)
+        public int GetHashCode((OperationFlags Flags, IMethodSymbol Method, ITypeSymbol? ParameterType, string ParameterMap, Location? UniqueLocation, AdditionalCommandState? AdditionalCommandState, bool ViaCommandDefinition) obj)
         {
             var hash = (int)obj.Flags;
             hash *= -47;
@@ -1567,6 +1582,8 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             {
                 hash += obj.AdditionalCommandState.GetHashCode();
             }
+            hash *= -47;
+            hash += obj.ViaCommandDefinition ? 1 : 0;
             return hash;
         }
     }

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -193,6 +193,9 @@ internal static class Inspection
         return result;
     }
 
+    public static bool IsCommandDefinition(this ITypeSymbol? typeSymbol) 
+        => typeSymbol.IsDapperType("CommandDefinition") && typeSymbol?.TypeKind == TypeKind.Struct;
+
     public static bool IsSqlClient(ITypeSymbol? typeSymbol) => typeSymbol is
     {
         Name: "SqlCommand",

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -1294,7 +1294,7 @@ internal static class Inspection
     public static bool HasAll(this OperationFlags value, OperationFlags testFor) => (value & testFor) == testFor;
 
     public static bool TryGetConstantValue<T>(IOperation op, out T? value)
-            => TryGetConstantValueWithSyntax(op, out value, out _, out _);
+            => TryGetStringConstantValueWithSyntax(op, out value, out _, out _);
     
     public static ITypeSymbol? GetResultType(this IInvocationOperation invocation, OperationFlags flags)
     {
@@ -1313,7 +1313,35 @@ internal static class Inspection
         ? symbol.NullableAnnotation == NullableAnnotation.Annotated
         : symbol.NullableAnnotation != NullableAnnotation.NotAnnotated;
 
-    public static bool TryGetConstantValueWithSyntax<T>(IOperation val, out T? value, out SyntaxNode? syntax, out StringSyntaxKind? syntaxKind)
+    public static bool TryGetEnumConstantValueWithSyntax<T>(IOperation val, out T? value)
+    {
+        if (val.ConstantValue.HasValue)
+        {
+            value = (T?)val.ConstantValue.Value;
+            return true;
+        }
+        if (val is IArgumentOperation arg)
+        {
+            val = arg.Value;
+        }
+        // work through any implicit/explicit conversion steps
+        while (val is IConversionOperation conv)
+        {
+            val = conv.Operand;
+        }
+        
+        // type-level constants
+        if (val is IFieldReferenceOperation field && field.Field.HasConstantValue)
+        {
+            value = (T?)field.Field.ConstantValue;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    public static bool TryGetStringConstantValueWithSyntax<T>(IOperation val, out T? value, out SyntaxNode? syntax, out StringSyntaxKind? syntaxKind)
     {
         try
         {

--- a/src/Dapper.AOT.Analyzers/Internal/Roslyn/TypeSymbolExtensions.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Roslyn/TypeSymbolExtensions.cs
@@ -145,6 +145,19 @@ internal static class TypeSymbolExtensions
     /// </returns>
     public static bool IsImmutableArray(this ITypeSymbol? typeSymbol) => IsStandardCollection(typeSymbol, "ImmutableArray", "Immutable", TypeKind.Struct);
 
+    public static bool IsDapperType(this ITypeSymbol? typeSymbol, string expectedName)
+    {
+        if (typeSymbol is null) return false;
+        return typeSymbol.Name == expectedName && typeSymbol.ContainingNamespace is
+        {
+            Name: "Dapper",
+            ContainingNamespace:
+            {
+                IsGlobalNamespace: true
+            }
+        };
+    }
+
     private static bool IsStandardCollection(ITypeSymbol? type, string name, string nsName = "Generic", TypeKind kind = TypeKind.Class)
         => type is INamedTypeSymbol named
             && named.Name == name

--- a/test/Dapper.AOT.Test.Integration.Executables/Models/CommandDefinitionPoco.cs
+++ b/test/Dapper.AOT.Test.Integration.Executables/Models/CommandDefinitionPoco.cs
@@ -1,0 +1,9 @@
+﻿namespace Dapper.AOT.Test.Integration.Executables.Models;
+
+public class CommandDefinitionPoco
+{
+    public const string TableName = "commandDefinitionPoco";
+
+    public int Id { get; set; }
+    public string? Name { get; set; }
+}

--- a/test/Dapper.AOT.Test.Integration.Executables/UserCode/CommandDefinition/CommandDefinitionUsage.cs
+++ b/test/Dapper.AOT.Test.Integration.Executables/UserCode/CommandDefinition/CommandDefinitionUsage.cs
@@ -1,0 +1,26 @@
+﻿using System.Data;
+using System.Linq;
+using System.Threading;
+using Dapper;
+using Dapper.AOT.Test.Integration.Executables.Models;
+
+namespace Dapper.AOT.Test.Integration.Executables.UserCode;
+
+[DapperAot]
+public class CommandDefinitionUsage : IExecutable<CommandDefinitionPoco>
+{
+    public CommandDefinitionPoco Execute(IDbConnection connection)
+    {
+        var results = connection.Query<CommandDefinitionPoco>(
+            new CommandDefinition(
+                commandText: $"select * from {CommandDefinitionPoco.TableName} where name = @name",
+                parameters: new
+                {
+                    name = "my-data"
+                },
+                cancellationToken: CancellationToken.None)
+        );
+
+        return results.First();
+    }
+}

--- a/test/Dapper.AOT.Test.Integration/CommandDefinitionTests.cs
+++ b/test/Dapper.AOT.Test.Integration/CommandDefinitionTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Data;
+using Dapper.AOT.Test.Integration.Executables.Models;
+using Dapper.AOT.Test.Integration.Executables.UserCode;
+using Dapper.AOT.Test.Integration.Setup;
+
+namespace Dapper.AOT.Test.Integration;
+
+[Collection(SharedPostgresqlClient.Collection)]
+public class CommandDefinitionTests : IntegrationTestsBase
+{
+    public CommandDefinitionTests(PostgresqlFixture fixture) : base(fixture)
+    {
+    }
+
+    protected override void SetupDatabase(IDbConnection dbConnection)
+    {
+        base.SetupDatabase(dbConnection);
+        
+        dbConnection.Execute($"""
+            CREATE TABLE IF NOT EXISTS {CommandDefinitionPoco.TableName}(
+                id     integer PRIMARY KEY,
+                name   varchar(40)
+            );
+
+            TRUNCATE {CommandDefinitionPoco.TableName};
+            
+            INSERT INTO {CommandDefinitionPoco.TableName} (id, name)
+            VALUES (1, 'my-data'),
+                   (2, 'my-poco'),
+                   (3, 'your-data');
+        """);
+    }
+
+    [Fact]
+    public void CommandDefinition_BasicUsage_InterceptsAndReturnsExpectedData()
+    {
+        var result = ExecuteInterceptedUserCode<CommandDefinitionUsage, CommandDefinitionPoco>(DbConnection);
+        
+        Assert.NotNull(result);
+        Assert.True(result.Id.Equals(1));
+        Assert.Equal("my-data", result.Name);
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/CommandDefinition.input.cs
+++ b/test/Dapper.AOT.Test/Interceptors/CommandDefinition.input.cs
@@ -1,0 +1,61 @@
+﻿using Dapper;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using System.Threading;
+
+[module: DapperAot]
+
+public static class Foo
+{
+    static void Run(DbConnection connection)
+    {
+        var sql = "sp_crunch";
+
+       // 0: sql comes as local var
+       _ = connection.ExecuteScalar<string>(new CommandDefinition(
+           sql,
+           new { X = 3 },
+           commandType: CommandType.StoredProcedure,
+           flags: CommandFlags.Buffered,
+           cancellationToken: CancellationToken.None));
+
+        // 1: sql inline
+        _ = connection.ExecuteScalarAsync<string>(new CommandDefinition(
+            "sp_crunch",
+            new { X = 3 },
+            commandType: CommandType.StoredProcedure,
+            flags: CommandFlags.Buffered,
+            cancellationToken: CancellationToken.None));
+
+        // 2: very limited setupdap
+        _ = connection.ExecuteScalarAsync<string>(new CommandDefinition(
+            "select * from table where X = @X",
+            new { X = 3 })
+        );
+
+        // 3: no async
+        _ = connection.ExecuteScalar<string>(new CommandDefinition(
+            "select * from table where X = @X",
+            new { X = 3 })
+        );
+
+        // 4: command definition as local var
+        var local = new CommandDefinition(
+            "select * from table where X = @X",
+            new { X = 3 }
+        );
+        _ = connection.ExecuteScalarAsync<string>(local);
+
+        // 5: query via command definition
+        var results = connection.Query<string>(
+            new CommandDefinition(
+                commandText: "select * from table where name = @name",
+                parameters: new
+                {
+                    name = "my-data"
+                },
+                cancellationToken: CancellationToken.None)
+        );
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/CommandDefinition.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/CommandDefinition.output.cs
@@ -1,0 +1,193 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 16, 23)]
+        internal static string? ExecuteScalar0(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
+        {
+            // Execute, TypedResult, HasParameters, StoredProcedure, Scalar, KnownParameters
+            // takes parameter: <anonymous type: int X>
+            // parameter map: X
+            // returns data: string
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
+            global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalar<string>(command.Parameters);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 24, 24)]
+        internal static global::System.Threading.Tasks.Task<string?> ExecuteScalarAsync1(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
+        {
+            // Execute, Async, TypedResult, HasParameters, StoredProcedure, Scalar, KnownParameters
+            // takes parameter: <anonymous type: int X>
+            // parameter map: X
+            // returns data: string
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
+            global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 32, 24)]
+        internal static global::System.Threading.Tasks.Task<string?> ExecuteScalarAsync2(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
+        {
+            // Execute, Async, TypedResult, HasParameters, Text, Scalar, KnownParameters
+            // takes parameter: <anonymous type: int X>
+            // parameter map: X
+            // returns data: string
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
+            global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 38, 24)]
+        internal static string? ExecuteScalar3(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
+        {
+            // Execute, TypedResult, HasParameters, Text, Scalar, KnownParameters
+            // takes parameter: <anonymous type: int X>
+            // parameter map: X
+            // returns data: string
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
+            global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalar<string>(command.Parameters);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 48, 24)]
+        internal static global::System.Threading.Tasks.Task<string?> ExecuteScalarAsync4(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
+        {
+            // Execute, Async, TypedResult, Scalar
+            // returns data: string
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Parameters is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, DefaultCommandFactory).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 51, 34)]
+        internal static global::System.Collections.Generic.IEnumerable<string> Query5(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
+        {
+            // Query, TypedResult, HasParameters, Buffered, Text, KnownParameters
+            // takes parameter: <anonymous type: string name>
+            // parameter map: name
+            // returns data: string
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
+            global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(command.Buffered is true); 
+            global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory1.Instance).QueryBuffered(command.Parameters, global::Dapper.RowFactory.Inbuilt.Value<string>());
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class CommandFactory0 : CommonCommandFactory<object?> // <anonymous type: int X>
+        {
+            internal static readonly CommandFactory0 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { X = default(int) }); // expected shape
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "X";
+                p.DbType = global::System.Data.DbType.Int32;
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                p.Value = AsValue(typed.X);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { X = default(int) }); // expected shape
+                var ps = cmd.Parameters;
+                ps[0].Value = AsValue(typed.X);
+
+            }
+            public override bool CanPrepare => true;
+
+        }
+
+        private sealed class CommandFactory1 : CommonCommandFactory<object?> // <anonymous type: string name>
+        {
+            internal static readonly CommandFactory1 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { name = default(string)! }); // expected shape
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "name";
+                p.DbType = global::System.Data.DbType.String;
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                SetValueWithDefaultSize(p, typed.name);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { name = default(string)! }); // expected shape
+                var ps = cmd.Parameters;
+                ps[0].Value = AsValue(typed.name);
+
+            }
+            public override bool CanPrepare => true;
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/CommandDefinition.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/CommandDefinition.output.cs
@@ -14,7 +14,7 @@ namespace Dapper.AOT // interceptors must be in a known namespace
             // returns data: string
             global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
             global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.StoredProcedure);
-            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false);
             global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
 
             return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalar<string>(command.Parameters);
@@ -30,7 +30,7 @@ namespace Dapper.AOT // interceptors must be in a known namespace
             // returns data: string
             global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
             global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.StoredProcedure);
-            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false);
             global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
 
             return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);
@@ -46,7 +46,7 @@ namespace Dapper.AOT // interceptors must be in a known namespace
             // returns data: string
             global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
             global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
-            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false);
             global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
 
             return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);
@@ -62,7 +62,7 @@ namespace Dapper.AOT // interceptors must be in a known namespace
             // returns data: string
             global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
             global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
-            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false);
             global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
 
             return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalar<string>(command.Parameters);
@@ -75,7 +75,7 @@ namespace Dapper.AOT // interceptors must be in a known namespace
             // Execute, Async, TypedResult, Scalar
             // returns data: string
             global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
-            global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
+            global::System.Diagnostics.Debug.Assert(command.Buffered is false);
             global::System.Diagnostics.Debug.Assert(command.Parameters is null);
 
             return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, DefaultCommandFactory).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);
@@ -91,7 +91,7 @@ namespace Dapper.AOT // interceptors must be in a known namespace
             // returns data: string
             global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
             global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
-            global::System.Diagnostics.Debug.Assert(command.Buffered is true); 
+            global::System.Diagnostics.Debug.Assert(command.Buffered is true);
             global::System.Diagnostics.Debug.Assert(command.Parameters is not null);
 
             return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory1.Instance).QueryBuffered(command.Parameters, global::Dapper.RowFactory.Inbuilt.Value<string>());

--- a/test/Dapper.AOT.Test/Interceptors/CommandDefinition.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/CommandDefinition.output.txt
@@ -1,0 +1,22 @@
+Input code has 1 diagnostics from 'Interceptors/CommandDefinition.input.cs':
+
+Hidden CS8019 Interceptors/CommandDefinition.input.cs L4 C1
+Unnecessary using directive.
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 6 of 6 possible call-sites using 6 interceptors, 2 commands and 0 readers
+Output code has 1 diagnostics from 'Interceptors/CommandDefinition.input.cs':
+
+Hidden CS8019 Interceptors/CommandDefinition.input.cs L4 C1
+Unnecessary using directive.
+Output code has 3 diagnostics from 'Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs':
+
+Warning CS8619 Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs L36 C20
+Nullability of reference types in value of type 'Task<string>' doesn't match target type 'Task<string?>'.
+
+Warning CS8619 Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs L52 C20
+Nullability of reference types in value of type 'Task<string>' doesn't match target type 'Task<string?>'.
+
+Warning CS8619 Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs L81 C20
+Nullability of reference types in value of type 'Task<string>' doesn't match target type 'Task<string?>'.


### PR DESCRIPTION
Current PR adds a support to parse use cases with `CommandDefinition`. 

## Usage check
If an user invocation has 2 or more parameters which are 1) `cnn`; 2) `command` where it is of type `CommandDefinition`, then I consider it to be a proper Dapper usage with `CommandDefinition`.

DapperAnalyzer has built-in argument processing to fix sql / detect buffering etc.
https://github.com/DapperLib/DapperAOT/blob/4f8cd50639a4b1d489cdff0583d351578246c78e/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs#L514-L517

Unfortunately, it is too complicated to cover many other usages of `CommandDefinition`, so I only added a case for in-place object creation:
```
_ = connection.Query<string>(new CommandDefinition(...));
```
Other cases will work (i.e. `CommandDefinition` as local variable), but will not have argument processing done.

## Generator
Since the Dapper.AOT has its own API, it is very easy to just pass in the same parameters who are the `CommandDefinition` members. So I just do this for example:
```
[global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\CommandDefinition.input.cs", 32, 24)]
internal static global::System.Threading.Tasks.Task<string?> ExecuteScalarAsync2(this global::System.Data.IDbConnection cnn, global::Dapper.CommandDefinition command)
{
    // Execute, Async, TypedResult, HasParameters, Text, Scalar, KnownParameters
    // takes parameter: <anonymous type: int X>
    // parameter map: X
    // returns data: string
    global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(command.CommandText));
    global::System.Diagnostics.Debug.Assert((command.CommandType ?? global::Dapper.DapperAotExtensions.GetCommandType(command.CommandText)) == global::System.Data.CommandType.Text);
    global::System.Diagnostics.Debug.Assert(command.Buffered is false); 
    global::System.Diagnostics.Debug.Assert(command.Parameters is not null);

    return global::Dapper.DapperAotExtensions.Command(cnn, command.Transaction, command.CommandText, command.CommandType ?? default, command.CommandTimeout ?? default, CommandFactory0.Instance).ExecuteScalarAsync<string>(command.Parameters, cancellationToken: command.CancellationToken);

}
```

`CommandDefinition` implementation is very convenient for such usage - for example I dont care what CancellationToken to pass in, because if it is not passed into `CommandDefinition`, it will be [simply default](https://github.com/DapperLib/Dapper/blob/5c7143f2e3585d4708294a3b0530a134e18ace86/Dapper/CommandDefinition.cs#L119). So I just map all members into the underlying SQL API

## Tests
Added code-generation + integration tests. 

Fixes #112