### PR TITLE
chore(CI): update deprecated ubuntu version

### DIFF
--- a/.github/workflows/dotnet-integration.yml
+++ b/.github/workflows/dotnet-integration.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu 20.04 deprecated: https://github.com/actions/runner-images/issues/11101