### PR TITLE
feat: TypeHandler support

### DIFF
--- a/docs/rules/DAP050.md
+++ b/docs/rules/DAP050.md
@@ -1,0 +1,20 @@
+# DAP050
+
+Duplicate classes have been registered as type handlers for the same type,
+meaning it's not possible to determine which to use when handling the type.
+Note type handlers can be registered at the assembly and module level, so
+ensure the type used for the `TValue` parameter in the attribute is only
+specified once.
+
+Bad:
+
+``` c#
+[module: TypeHandler<MyClass, MyHandler1>]
+[module: TypeHandler<MyClass, MyHandler2>]
+```
+
+Good:
+
+``` c#
+[module: TypeHandler<MyClass, MyHandler>]
+```

--- a/docs/rules/DAP051.md
+++ b/docs/rules/DAP051.md
@@ -1,0 +1,18 @@
+# DAP051
+
+TypeHandler attribute points to a type handler class (TTypeHandler in TypeHandler<TValue, TTypeHandler>) that is not a valid named type,
+or cannot be constructed as required by Dapper AOT.
+The type handler must be a concrete (non-abstract) class and must have a public parameterless constructor.
+
+Bad:
+
+``` c#
+[module: TypeHandler<MyClass, IMyHandler>]
+[module: TypeHandler<MyClass, MyAbstractHandler>]
+```
+
+Good:
+
+``` c#
+[module: TypeHandler<MyClass, MyHandler>]
+```

--- a/docs/typehandlers.md
+++ b/docs/typehandlers.md
@@ -1,0 +1,26 @@
+# Type Handlers
+
+Dapper AOT provides a mechanism to customize how specific .NET types are mapped to and from database values.
+This is achieved through Type Handlers, which allow you to define custom serialization for parameters sent 
+to the database and custom deserialization for values read from query results. 
+This is similar to SqlMapper.TypeHandler in vanilla Dapper, but with a specific AOT-compatible registration process.
+
+To register your custom type handler, you use either an assembly or module level attribute. 
+Both have the same effect.
+This attribute tells Dapper AOT which .NET type (TValue) your handler processes 
+and which class (TTypeHandler) is responsible for that processing.
+
+``` csharp
+// Example using a module-level attribute
+using Dapper;
+
+[module: TypeHandler<YourDotNetType, YourCustomTypeHandler>]
+
+// Example using an assembly-level attribute (often in AssemblyInfo.cs or a shared file)
+// [assembly: TypeHandler<YourDotNetType, YourCustomTypeHandler>]
+```
+
+Your custom type handler class must:
+* Inherit from Dapper.TypeHandler<TValue>, where TValue is the .NET type it handles.
+* Have a public parameterless constructor (new()).
+* Implement (override) the necessary virtual methods for your specific conversion needs.

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Diagnostics.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Diagnostics.cs
@@ -12,6 +12,9 @@ partial class DapperInterceptorGenerator
             LanguageVersionTooLow = LibraryWarning("DAP004", "Language version too low", "Interceptors require at least C# version 11"),
 
             CommandPropertyNotFound = LibraryWarning("DAP033", "Command property not found", "Command property {0}.{1} was not found or was not valid; attribute will be ignored"),
-            CommandPropertyReserved = LibraryWarning("DAP034", "Command property reserved", "Command property {1} is reserved for internal usage; attribute will be ignored");
+            CommandPropertyReserved = LibraryWarning("DAP034", "Command property reserved", "Command property {1} is reserved for internal usage; attribute will be ignored"),
+            
+            DuplicateTypeHandlers = LibraryError("DAP050", "Duplicate type handlers", "Type {0} has multiple type handlers registered"),
+            InvalidTypeHandlerSymbol = LibraryError("DAP051", "Invalid type handler symbol", "Type handler symbol {0} is not a valid named type; attribute will be ignored");
     }
 }

--- a/src/Dapper.AOT/TypeHandlerT.cs
+++ b/src/Dapper.AOT/TypeHandlerT.cs
@@ -10,7 +10,7 @@ namespace Dapper;
 /// when processing values of type <typeparamref name="TValue"/>
 /// </summary>
 [ImmutableObject(true)]
-[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method, AllowMultiple = true)]
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module, AllowMultiple = true)]
 public sealed class TypeHandlerAttribute<TValue, TTypeHandler> : Attribute
     where TTypeHandler : TypeHandler<TValue>, new()
 {}
@@ -31,4 +31,10 @@ public abstract class TypeHandler<T>
     /// </summary>
     public virtual T Parse(DbParameter parameter)
         => CommandUtils.As<T>(parameter.Value);
+
+    /// <summary>
+    /// Reads the value from the results
+    /// </summary>
+    public virtual T Read(DbDataReader reader, int columnOffset)
+        => CommandUtils.As<T>(reader.GetValue(columnOffset));
 }

--- a/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.cs
@@ -115,16 +115,16 @@ namespace Dapper.AOT // interceptors must be in a known namespace
                         case 3:
                             result.X = GetValue<int>(reader, columnOffset);
                             break;
-                        case 2:
+                        case 1:
                             result.Z = reader.IsDBNull(columnOffset) ? (double?)null : reader.GetDouble(columnOffset);
                             break;
-                        case 5:
+                        case 4:
                             result.Z = reader.IsDBNull(columnOffset) ? (double?)null : GetValue<double>(reader, columnOffset);
                             break;
-                        case 4:
+                        case 2:
                             result.Y = reader.IsDBNull(columnOffset) ? (string?)null : reader.GetString(columnOffset);
                             break;
-                        case 7:
+                        case 5:
                             result.Y = reader.IsDBNull(columnOffset) ? (string?)null : GetValue<string>(reader, columnOffset);
                             break;
 
@@ -161,10 +161,10 @@ namespace Dapper.AOT // interceptors must be in a known namespace
                         case 0:
                             result.X = reader.GetInt32(columnOffset);
                             break;
-                        case 2:
+                        case 1:
                             result.Z = reader.IsDBNull(columnOffset) ? (double?)null : reader.GetDouble(columnOffset);
                             break;
-                        case 4:
+                        case 2:
                             result.Y = reader.IsDBNull(columnOffset) ? (string?)null : reader.GetString(columnOffset);
                             break;
 

--- a/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.netfx.cs
+++ b/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.netfx.cs
@@ -115,16 +115,16 @@ namespace Dapper.AOT // interceptors must be in a known namespace
                         case 3:
                             result.X = GetValue<int>(reader, columnOffset);
                             break;
-                        case 2:
+                        case 1:
                             result.Z = reader.IsDBNull(columnOffset) ? (double?)null : reader.GetDouble(columnOffset);
                             break;
-                        case 5:
+                        case 4:
                             result.Z = reader.IsDBNull(columnOffset) ? (double?)null : GetValue<double>(reader, columnOffset);
                             break;
-                        case 4:
+                        case 2:
                             result.Y = reader.IsDBNull(columnOffset) ? (string?)null : reader.GetString(columnOffset);
                             break;
-                        case 7:
+                        case 5:
                             result.Y = reader.IsDBNull(columnOffset) ? (string?)null : GetValue<string>(reader, columnOffset);
                             break;
 
@@ -161,10 +161,10 @@ namespace Dapper.AOT // interceptors must be in a known namespace
                         case 0:
                             result.X = reader.GetInt32(columnOffset);
                             break;
-                        case 2:
+                        case 1:
                             result.Z = reader.IsDBNull(columnOffset) ? (double?)null : reader.GetDouble(columnOffset);
                             break;
-                        case 4:
+                        case 2:
                             result.Y = reader.IsDBNull(columnOffset) ? (string?)null : reader.GetString(columnOffset);
                             break;
 

--- a/test/Dapper.AOT.Test/Interceptors/TypeHandler.input.cs
+++ b/test/Dapper.AOT.Test/Interceptors/TypeHandler.input.cs
@@ -1,0 +1,35 @@
+﻿using Dapper;
+using System.Data;
+using System.Data.Common;
+
+[module: DapperAot]
+[module: TypeHandler<CustomClass, CustomClassTypeHandler>]
+
+public class CustomClassTypeHandler : TypeHandler<CustomClass>
+{
+}
+
+public class CustomClass
+{
+}
+
+public static class Foo
+{
+    static void SomeCode(DbConnection connection, string bar, bool isBuffered)
+    {
+        _ = connection.Query<MyType>("def");
+        _ = connection.Query<int>("def", new { Param = new CustomClass() });
+        _ = connection.Query<int>("@OutputValue = def", new CommandParameters());
+    }
+
+    public class CommandParameters
+    {
+        [DbValue(Direction = ParameterDirection.Output)]
+        public CustomClass OutputValue { get; set; }
+    }
+
+    public class MyType
+    {
+        public CustomClass C { get; set; }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.cs
@@ -1,0 +1,198 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private static global::CustomClassTypeHandler? __handler1;
+        private static global::CustomClassTypeHandler __Handler1 => __handler1 ??= new global::CustomClassTypeHandler();
+        #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\TypeHandler.input.cs", 20, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<global::Foo.MyType> Query0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, Buffered, StoredProcedure, BindResultsByName
+            // returns data: global::Foo.MyType
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), DefaultCommandFactory).QueryBuffered(param, RowFactory0.Instance);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\TypeHandler.input.cs", 21, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<int> Query1(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, HasParameters, Buffered, StoredProcedure, KnownParameters
+            // takes parameter: <anonymous type: CustomClass Param>
+            // parameter map: Param
+            // returns data: int
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), CommandFactory0.Instance).QueryBuffered(param, global::Dapper.RowFactory.Inbuilt.Value<int>());
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\TypeHandler.input.cs", 22, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<int> Query2(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, HasParameters, Buffered, Text, KnownParameters
+            // takes parameter: global::Foo.CommandParameters
+            // parameter map: OutputValue
+            // returns data: int
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.Text, commandTimeout.GetValueOrDefault(), CommandFactory1.Instance).QueryBuffered((global::Foo.CommandParameters)param!, global::Dapper.RowFactory.Inbuilt.Value<int>());
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class RowFactory0 : global::Dapper.RowFactory<global::Foo.MyType>
+        {
+            internal static readonly RowFactory0 Instance = new();
+            private RowFactory0() {}
+            public override object? Tokenize(global::System.Data.Common.DbDataReader reader, global::System.Span<int> tokens, int columnOffset)
+            {
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    int token = -1;
+                    var name = reader.GetName(columnOffset);
+                    var type = reader.GetFieldType(columnOffset);
+                    switch (NormalizedHash(name))
+                    {
+                        case 3859557458U when NormalizedEquals(name, "c"):
+                            token = 0; // two tokens for right-typed and type-flexible
+                            break;
+
+                    }
+                    tokens[i] = token;
+                    columnOffset++;
+
+                }
+                return null;
+            }
+            public override global::Foo.MyType Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)
+            {
+                global::Foo.MyType result = new();
+                foreach (var token in tokens)
+                {
+                    switch (token)
+                    {
+                        case 0:
+                            result.C = reader.IsDBNull(columnOffset) ? (global::CustomClass?)null : __Handler1.Read(reader, columnOffset);
+                            break;
+
+                    }
+                    columnOffset++;
+
+                }
+                return result;
+
+            }
+
+        }
+
+        private sealed class CommandFactory0 : CommonCommandFactory<object?> // <anonymous type: CustomClass Param>
+        {
+            internal static readonly CommandFactory0 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Param = default(global::CustomClass)! }); // expected shape
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "Param";
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                __Handler1.SetValue((global::System.Data.Common.DbParameter)p, typed.Param);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Param = default(global::CustomClass)! }); // expected shape
+                var ps = cmd.Parameters;
+                __Handler1.SetValue((global::System.Data.Common.DbParameter)ps[0], typed.Param);
+
+            }
+
+        }
+
+        private sealed class CommandFactory1 : CommonCommandFactory<global::Foo.CommandParameters>
+        {
+            internal static readonly CommandFactory1 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.CommandParameters args)
+            {
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "OutputValue";
+                p.Direction = global::System.Data.ParameterDirection.Output;
+                p.Value = global::System.DBNull.Value;
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.CommandParameters args)
+            {
+                var ps = cmd.Parameters;
+                ps[0].Value = global::System.DBNull.Value;
+
+            }
+            public override bool RequirePostProcess => true;
+
+            public override void PostProcess(in global::Dapper.UnifiedCommand cmd, global::Foo.CommandParameters args, int rowCount)
+            {
+                var ps = cmd.Parameters;
+                args.OutputValue = __Handler1.Parse((global::System.Data.Common.DbParameter)ps[0]);
+                base.PostProcess(in cmd, args, rowCount);
+
+            }
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.netfx.cs
+++ b/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.netfx.cs
@@ -1,0 +1,198 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private static global::CustomClassTypeHandler? __handler1;
+        private static global::CustomClassTypeHandler __Handler1 => __handler1 ??= new global::CustomClassTypeHandler();
+        #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\TypeHandler.input.cs", 20, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<global::Foo.MyType> Query0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, Buffered, StoredProcedure, BindResultsByName
+            // returns data: global::Foo.MyType
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), DefaultCommandFactory).QueryBuffered(param, RowFactory0.Instance);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\TypeHandler.input.cs", 21, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<int> Query1(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, HasParameters, Buffered, StoredProcedure, KnownParameters
+            // takes parameter: <anonymous type: CustomClass Param>
+            // parameter map: Param
+            // returns data: int
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), CommandFactory0.Instance).QueryBuffered(param, global::Dapper.RowFactory.Inbuilt.Value<int>());
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\TypeHandler.input.cs", 22, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<int> Query2(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, HasParameters, Buffered, Text, KnownParameters
+            // takes parameter: global::Foo.CommandParameters
+            // parameter map: OutputValue
+            // returns data: int
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.Text, commandTimeout.GetValueOrDefault(), CommandFactory1.Instance).QueryBuffered((global::Foo.CommandParameters)param!, global::Dapper.RowFactory.Inbuilt.Value<int>());
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class RowFactory0 : global::Dapper.RowFactory<global::Foo.MyType>
+        {
+            internal static readonly RowFactory0 Instance = new();
+            private RowFactory0() {}
+            public override object? Tokenize(global::System.Data.Common.DbDataReader reader, global::System.Span<int> tokens, int columnOffset)
+            {
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    int token = -1;
+                    var name = reader.GetName(columnOffset);
+                    var type = reader.GetFieldType(columnOffset);
+                    switch (NormalizedHash(name))
+                    {
+                        case 3859557458U when NormalizedEquals(name, "c"):
+                            token = 0; // two tokens for right-typed and type-flexible
+                            break;
+
+                    }
+                    tokens[i] = token;
+                    columnOffset++;
+
+                }
+                return null;
+            }
+            public override global::Foo.MyType Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)
+            {
+                global::Foo.MyType result = new();
+                foreach (var token in tokens)
+                {
+                    switch (token)
+                    {
+                        case 0:
+                            result.C = reader.IsDBNull(columnOffset) ? (global::CustomClass?)null : __Handler1.Read(reader, columnOffset);
+                            break;
+
+                    }
+                    columnOffset++;
+
+                }
+                return result;
+
+            }
+
+        }
+
+        private sealed class CommandFactory0 : CommonCommandFactory<object?> // <anonymous type: CustomClass Param>
+        {
+            internal static readonly CommandFactory0 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Param = default(global::CustomClass)! }); // expected shape
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "Param";
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                __Handler1.SetValue((global::System.Data.Common.DbParameter)p, typed.Param);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Param = default(global::CustomClass)! }); // expected shape
+                var ps = cmd.Parameters;
+                __Handler1.SetValue((global::System.Data.Common.DbParameter)ps[0], typed.Param);
+
+            }
+
+        }
+
+        private sealed class CommandFactory1 : CommonCommandFactory<global::Foo.CommandParameters>
+        {
+            internal static readonly CommandFactory1 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.CommandParameters args)
+            {
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "OutputValue";
+                p.Direction = global::System.Data.ParameterDirection.Output;
+                p.Value = global::System.DBNull.Value;
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.CommandParameters args)
+            {
+                var ps = cmd.Parameters;
+                ps[0].Value = global::System.DBNull.Value;
+
+            }
+            public override bool RequirePostProcess => true;
+
+            public override void PostProcess(in global::Dapper.UnifiedCommand cmd, global::Foo.CommandParameters args, int rowCount)
+            {
+                var ps = cmd.Parameters;
+                args.OutputValue = __Handler1.Parse((global::System.Data.Common.DbParameter)ps[0]);
+                base.PostProcess(in cmd, args, rowCount);
+
+            }
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 3 of 3 possible call-sites using 3 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/TypeHandler.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 3 of 3 possible call-sites using 3 interceptors, 2 commands and 1 readers


### PR DESCRIPTION
This PR represents an attempt to resolve issue #159.

The prior approach of the source generator (#117) inadvertently led to the generation of code that instantiated a new `TypeHandler` object for each parameter or column read operation (new global::CustomClassTypeHandler().Read(...)). This could lead to unnecessary object allocations and a minor performance overhead, especially in high-volume scenarios.

This PR introduces a `TypeHandlerInstanceRegistry` and modifies the code generation to ensure that:
- A single, static instance of each registered TypeHandler is created within the generated interceptor file (e.g., `__Handler1`, `__Handler2`).
- All subsequent operations (setting parameters, parsing output parameters, reading result set columns) for a given type handler utilize this pre-allocated, static instance.
