### PR TITLE
fix TypeAccessor not including inherited members (#93)

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
@@ -535,37 +535,46 @@ public sealed partial class TypeAccessorInterceptorGenerator : InterceptorGenera
     {
         var members = new List<MemberData>();
         int memberNumber = 0;
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var type in typeSymbol.GetMembers())
+        var tier = typeSymbol;
+        while (tier is not null and not IErrorTypeSymbol)
         {
-            if (!CodeWriter.IsGettableInstanceMember(type, out var member) || !CodeWriter.IsSettableInstanceMember(type, out _))
+            foreach (var type in tier.GetMembers())
             {
-                // TODO not sure if we can use not settable or gettable field\property
-                continue;
+                if (!CodeWriter.IsGettableInstanceMember(type, out var member) || !CodeWriter.IsSettableInstanceMember(type, out _))
+                {
+                    continue;
+                }
+
+                // skip members already seen at a more-derived level (handles `new` shadowing)
+                if (!seenNames.Add(type.Name)) continue;
+
+                if (type is IPropertySymbol property)
+                {
+                    members.Add(new()
+                    {
+                        Name = property.Name,
+                        Type = member.ToDisplayString(),
+                        TypeSymbol = property.Type,
+                        Number = memberNumber++,
+                        IsNullable = property.Type.IsNullable()
+                    });
+                }
+                if (type is IFieldSymbol field)
+                {
+                    members.Add(new()
+                    {
+                        Name = field.Name,
+                        Type = member.ToDisplayString(),
+                        TypeSymbol = field.Type,
+                        Number = memberNumber++,
+                        IsNullable = field.NullableAnnotation == NullableAnnotation.Annotated
+                    });
+                }
             }
 
-            if (type is IPropertySymbol property)
-            {
-                members.Add(new()
-                {
-                    Name = property.Name,
-                    Type = member.ToDisplayString(),
-                    TypeSymbol = property.Type,
-                    Number = memberNumber++,
-                    IsNullable = property.Type.IsNullable()
-                });
-            }
-            if (type is IFieldSymbol field)
-            {
-                members.Add(new()
-                {
-                    Name = field.Name,
-                    Type = member.ToDisplayString(),
-                    TypeSymbol = field.Type,
-                    Number = memberNumber++,
-                    IsNullable = field.NullableAnnotation == NullableAnnotation.Annotated
-                });
-            }
+            tier = tier.BaseType;
         }
 
 #pragma warning disable IDE0305 // Simplify collection initialization

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/TypeAccessorInterceptorGenerator.cs
@@ -535,7 +535,7 @@ public sealed partial class TypeAccessorInterceptorGenerator : InterceptorGenera
     {
         var members = new List<MemberData>();
         int memberNumber = 0;
-        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+        HashSet<string> seenNames = new(StringComparer.Ordinal);
 
         var tier = typeSymbol;
         while (tier is not null and not IErrorTypeSymbol)

--- a/test/Dapper.AOT.Test/Accessors/AccessorInterceptorTests.cs
+++ b/test/Dapper.AOT.Test/Accessors/AccessorInterceptorTests.cs
@@ -19,6 +19,31 @@ public class AccessorInterceptorTests : GeneratorTestBase
         where path.EndsWith(".input.cs", StringComparison.OrdinalIgnoreCase)
         select new object[] { path };
 
+    [Fact]
+    public void InheritedMembersAreIncluded()
+    {
+        const string source = @"
+using Dapper;
+[module: DapperAot]
+public static class Foo
+{
+    static void SomeCode()
+    {
+        _ = TypeAccessor.CreateAccessor(new Entity1());
+    }
+}
+public abstract class EntityBase { public long Id { get; set; } }
+public class Entity1 : EntityBase { public string Name { get; set; } }
+";
+        var result = Execute<TypeAccessorInterceptorGenerator>(source);
+        var generated = Assert.Single(result.Result.Results)
+            .GeneratedSources.Single().SourceText.ToString();
+
+        Assert.Contains("nameof(global::Entity1.Name)", generated);
+        Assert.Contains("nameof(global::Entity1.Id)", generated);
+        Assert.Contains("MemberCount => 2", generated);
+    }
+
     [Theory, MemberData(nameof(GetFiles))]
     public void Test(string path)
     {


### PR DESCRIPTION
Hey @mgravell,

for this issue you had already released a first patch, which didn't cover the following scenario:

TypeAccessorInterceptorGenerator.ConstructTypeMembers used a single typeSymbol.GetMembers() call without walking the type hierarchy. Now walks BaseType like Inspection.GetMembers already does.

#93 