### PR TITLE
Fix false-positive DAP026 for union/parenthesized queries ( #152)

### DIFF
--- a/src/Dapper.AOT.Analyzers/SqlAnalysis/TSqlProcessor.cs
+++ b/src/Dapper.AOT.Analyzers/SqlAnalysis/TSqlProcessor.cs
@@ -933,6 +933,10 @@ internal class TSqlProcessor
                     }
                 }
             }
+            else if (node.Into is null && node.QueryExpression is BinaryQueryExpression or QueryParenthesisExpression)
+            {
+                AddQuery(); // union/except/intersect/parens still produce a grid
+            }
 
             base.Visit(node);
         }

--- a/test/Dapper.AOT.Test/Verifiers/DAP025.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP025.cs
@@ -59,4 +59,12 @@ public class DAP025 : Verifier<DapperAnalyzer>
         INTO #MyTemporaryTable FROM MyTable
         """, SqlAnalysis.SqlParseInputFlags.ExpectNoQuery);
 
+    [Fact]
+    public Task ReportUnionWhenNoQueryExpected() => SqlVerifyAsync("""
+        select 1
+        union all
+        select 2
+        """, SqlAnalysis.SqlParseInputFlags.ExpectNoQuery,
+            Diagnostic(Diagnostics.ExecuteCommandWithQuery).WithLocation(Execute));
+
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP026.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP026.cs
@@ -60,4 +60,16 @@ public class DAP026 : Verifier<DapperAnalyzer>
         """, SqlAnalysis.SqlParseInputFlags.ExpectQuery,
             Diagnostic(Diagnostics.QueryCommandMissingQuery).WithLocation(Execute));
 
+    [Fact] // false positive scenario, https://github.com/DapperLib/DapperAOT/issues/152
+    public Task DoNotReportForUnionAll() => SqlVerifyAsync("""
+        select 1
+        union all
+        select 2
+        """, SqlAnalysis.SqlParseInputFlags.ExpectQuery);
+
+    [Fact]
+    public Task DoNotReportForParenthesizedQuery() => SqlVerifyAsync("""
+        (select 1)
+        """, SqlAnalysis.SqlParseInputFlags.ExpectQuery);
+
 }


### PR DESCRIPTION
Fixed #152 `Visit(SelectStatement)` only calls `AddQuery()` when the query expression is a `QuerySpecification`. A `union all` parses as a `BinaryQueryExpression`, so the `Query` flag never gets set and valid SQL like `select 1 union all select 2` gets reported as
"The command lacks a query". Parenthesized queries such as `(select 1)` hit the same hole — that one isn't in the issue, but it reproduces identically. 

The fix is one `else if` on the existing branch, handled at the `SelectStatement` level rather than by overriding `Visit(BinaryQueryExpression)`. Two reasons for that: a multi-branch union nests `BinaryQueryExpression`s, so a visitor override would call `AddQuery()` twice and wrongly flag it as multiple grids; and `insert ... select 1 union all select 2` doesn't route through `Visit(SelectStatement)`, so it correctly stays a non-query.

Both new DAP026 tests were confirmed failing on main with exactly the reported error before the change. I also added the mirror case to DAP025 — `Execute` with a union now reports "command has a query that will be ignored" — to show the flag is genuinely being set rather than the diagnostic just being suppressed. Full non-integration suite: 262 passing.

One thing I deliberately left alone: the per-column checks in the `QuerySpecification` branch (`select *`, duplicate column names, single-row `TOP` validation) still don't run on union branches. Extending those means refactoring that block into a method taking a `QuerySpecification`, which felt out of scope for a false-positive fix.