### PR TITLE
Check generic type arguments for accessibility (DAP017)

### DIFF
--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -309,6 +309,15 @@ internal static class Inspection
             {
                 return IsPublicOrAssemblyLocal(array.ElementType, assembly, out failingSymbol);
             }
+            if (symbol is INamedTypeSymbol { IsGenericType: true } generic)
+            {
+                // the type arguments matter too: List<Private> is as inaccessible as Private
+                foreach (var typeArg in generic.TypeArguments)
+                {
+                    if (typeArg is ITypeParameterSymbol) continue; // handled by InvolvesGenericTypeParameter
+                    if (!IsPublicOrAssemblyLocal(typeArg, assembly, out failingSymbol)) return false;
+                }
+            }
             switch (symbol.DeclaredAccessibility)
             {
                 case Accessibility.Public:

--- a/test/Dapper.AOT.Test/Verifiers/DAP017.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP017.cs
@@ -10,6 +10,7 @@ public class DAP017 : Verifier<DapperAnalyzer>
     [Fact]
     public Task NonPublicType() => CSVerifyAsync("""
         using Dapper;
+        using System.Collections.Generic;
         using System.Data.Common;
 
         internal class NestedInternal
@@ -25,6 +26,10 @@ public class DAP017 : Verifier<DapperAnalyzer>
                 void ArgsF(DbConnection conn, NestedInternal.InnerProtected args) => conn.Execute("somesql", {|#2:args|});
                 void ArgsG(DbConnection conn, NestedInternal.InnerProtectedInternal args) => conn.Execute("somesql", args);
                 void ArgsH(DbConnection conn, NestedInternal.InnerPrivateProtected args) => conn.Execute("somesql", {|#3:args|});
+                void ArgsI(DbConnection conn, List<NestedInternal.InnerPrivate> args) => conn.Execute("somesql", {|#8:args|});
+                void ArgsJ(DbConnection conn, List<OuterPublic> args) => conn.Execute("somesql", args);
+                void ArgsK(DbConnection conn, List<List<NestedInternal.InnerPrivate>> args) => conn.Execute("somesql", {|#9:args|});
+                void ArgsL(DbConnection conn, NestedInternal.InnerPrivate[] args) => conn.Execute("somesql", {|#10:args|});
 
                 void QueryA(DbConnection conn) => _ = conn.Query<OuterPublic>("somesql");
                 void QueryB(DbConnection conn) => _ = conn.Query<OuterInternal>("somesql");
@@ -34,6 +39,7 @@ public class DAP017 : Verifier<DapperAnalyzer>
                 void QueryF(DbConnection conn) => _ = conn.{|#6:Query<InnerProtected>|}("somesql");
                 void QueryG(DbConnection conn) => _ = conn.Query<InnerProtectedInternal>("somesql");
                 void QueryH(DbConnection conn) => _ = conn.{|#7:Query<InnerPrivateProtected>|}("somesql");
+                void QueryI(DbConnection conn) => _ = conn.{|#11:Query<InnerPrivateStruct?>|}("somesql");
 
             }
             [DapperAot(false)]
@@ -47,6 +53,10 @@ public class DAP017 : Verifier<DapperAnalyzer>
                 void ArgsF(DbConnection conn, NestedInternal.InnerProtected args) => conn.Execute("somesql", args);
                 void ArgsG(DbConnection conn, NestedInternal.InnerProtectedInternal args) => conn.Execute("somesql", args);
                 void ArgsH(DbConnection conn, NestedInternal.InnerPrivateProtected args) => conn.Execute("somesql", args);
+                void ArgsI(DbConnection conn, List<NestedInternal.InnerPrivate> args) => conn.Execute("somesql", args);
+                void ArgsJ(DbConnection conn, List<OuterPublic> args) => conn.Execute("somesql", args);
+                void ArgsK(DbConnection conn, List<List<NestedInternal.InnerPrivate>> args) => conn.Execute("somesql", args);
+                void ArgsL(DbConnection conn, NestedInternal.InnerPrivate[] args) => conn.Execute("somesql", args);
 
                 void QueryA(DbConnection conn) => _ = conn.Query<OuterPublic>("somesql");
                 void QueryB(DbConnection conn) => _ = conn.Query<OuterInternal>("somesql");
@@ -56,6 +66,7 @@ public class DAP017 : Verifier<DapperAnalyzer>
                 void QueryF(DbConnection conn) => _ = conn.Query<InnerProtected>("somesql");
                 void QueryG(DbConnection conn) => _ = conn.Query<InnerProtectedInternal>("somesql");
                 void QueryH(DbConnection conn) => _ = conn.Query<InnerPrivateProtected>("somesql");
+                void QueryI(DbConnection conn) => _ = conn.Query<InnerPrivateStruct?>("somesql");
             }
             public class InnerPublic { public int Id {get;set;} }
             protected class InnerProtected {}
@@ -65,6 +76,7 @@ public class DAP017 : Verifier<DapperAnalyzer>
             {
                 public class InnerInnerPublic {}
             }
+            private struct InnerPrivateStruct { public int Id {get;set;} }
         }
 
         public class OuterPublic { public int Id {get;set;} }
@@ -78,5 +90,9 @@ public class DAP017 : Verifier<DapperAnalyzer>
             Diagnostic(Diagnostics.NonPublicType).WithLocation(5).WithArguments("NestedInternal.InnerPrivate", "private"),
             Diagnostic(Diagnostics.NonPublicType).WithLocation(6).WithArguments("NestedInternal.InnerProtected", "protected"),
             Diagnostic(Diagnostics.NonPublicType).WithLocation(7).WithArguments("NestedInternal.InnerPrivateProtected", "private protected"),
+            Diagnostic(Diagnostics.NonPublicType).WithLocation(8).WithArguments("NestedInternal.InnerPrivate", "private"),
+            Diagnostic(Diagnostics.NonPublicType).WithLocation(9).WithArguments("NestedInternal.InnerPrivate", "private"),
+            Diagnostic(Diagnostics.NonPublicType).WithLocation(10).WithArguments("NestedInternal.InnerPrivate", "private"),
+            Diagnostic(Diagnostics.NonPublicType).WithLocation(11).WithArguments("NestedInternal.InnerPrivateStruct", "private"),
     ]);
 }


### PR DESCRIPTION
The accessibility check (`IsPublicOrAssemblyLocal`) recursed into array elements and containing types, but not generic type arguments. So `Execute(sql, new List<PrivateType>(...))` generated a `CommandFactory` naming a type the generated code cannot see — CS0122 in the consumer's build — while the equivalent `PrivateType[]` was correctly refused with DAP017.

I found this by enabling Dapper.AOT across the Dapper test suite: `PostgresqlTests` inserts a `List<Cat>` where `Cat` is a private nested class; the `Cat[]` overload two lines up was refused, the `List<Cat>` one emitted broken code.

Fix: recurse the type arguments (skipping type parameters, which `InvolvesGenericTypeParameter` already handles). New DAP017 verifier cases cover `List<Private>`, `List<List<Private>>`, `Private[]` (regression), and `Nullable<PrivateStruct>`; confirmed they fail without the fix. Full unit suite green (259).