### PR TITLE
Refuse enumerable parameters outside Execute

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -726,6 +726,15 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                     flags |= OperationFlags.DoNotGenerate;
                     reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.NonPublicType, argLocation, failing!.ToDisplayString(), NameAccessibility(failing)));
                 }
+                else if (Inspection.IsCollectionType(paramType, out _)
+                    && !(flags.HasAny(OperationFlags.Execute) && !flags.HasAny(OperationFlags.Scalar)))
+                {
+                    // enumerable parameters mean multi-exec, which is only valid for Execute;
+                    // vanilla Dapper throws for the rest ("An enumerable sequence of parameters ...
+                    // is not allowed in this context"), so: leave the call-site alone rather than
+                    // generating a command over the collection's own members
+                    flags |= OperationFlags.DoNotGenerate;
+                }
             }
         }
         return callLocation;

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.input.cs
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.input.cs
@@ -1,0 +1,24 @@
+using Dapper;
+using System.Collections.Generic;
+using System.Data.Common;
+
+[module: DapperAot]
+
+public static class Foo
+{
+    static void SomeCode(DbConnection connection)
+    {
+        // enumerable parameters mean multi-exec, which is only valid for Execute;
+        // vanilla Dapper throws for all of these, so they must not be intercepted
+        // (previously the array-of-anonymous case emitted unparseable code)
+        _ = connection.Query<Customer>("select X from Customers where X in @ids", new[] { new Customer { X = 1 } });
+        _ = connection.Query("select X from Customers", new List<Customer>());
+        _ = connection.Query("select X from Customers", new[] { new { Id = 1 } });
+        _ = connection.ExecuteScalar("select count(1) from Customers", new Customer[0]);
+
+        // multi-exec itself is still fine
+        connection.Execute("insert Customers (X) values (@X)", new List<Customer> { new Customer { X = 2 } });
+        connection.Execute("insert Customers (Id) values (@Id)", new[] { new { Id = 1 } });
+    }
+    public class Customer { public int X {get;set;} }
+}

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.cs
@@ -1,0 +1,126 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\QueryEnumerableParams.input.cs", 20, 20)]
+        internal static int Execute0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Execute, HasParameters, Text, KnownParameters
+            // takes parameter: global::System.Collections.Generic.List<global::Foo.Customer>
+            // parameter map: X
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.Text, commandTimeout.GetValueOrDefault(), CommandFactory0.Instance).Execute((global::System.Collections.Generic.List<global::Foo.Customer>)param!);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\QueryEnumerableParams.input.cs", 21, 20)]
+        internal static int Execute1(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Execute, HasParameters, Text, KnownParameters
+            // takes parameter: global::<anonymous type: int Id>[]
+            // parameter map: Id
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.Text, commandTimeout.GetValueOrDefault(), CommandFactory1.Instance).Execute((object?[])param!);
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class CommandFactory0 : CommonCommandFactory<global::Foo.Customer>
+        {
+            internal static readonly CommandFactory0 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.Customer args)
+            {
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "X";
+                p.DbType = global::System.Data.DbType.Int32;
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                p.Value = AsValue(args.X);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.Customer args)
+            {
+                var ps = cmd.Parameters;
+                ps[0].Value = AsValue(args.X);
+
+            }
+            public override bool CanPrepare => true;
+
+        }
+
+        private sealed class CommandFactory1 : CommonCommandFactory<object?> // <anonymous type: int Id>
+        {
+            internal static readonly CommandFactory1 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Id = default(int) }); // expected shape
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "Id";
+                p.DbType = global::System.Data.DbType.Int32;
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                p.Value = AsValue(typed.Id);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Id = default(int) }); // expected shape
+                var ps = cmd.Parameters;
+                ps[0].Value = AsValue(typed.Id);
+
+            }
+            public override bool CanPrepare => true;
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.netfx.cs
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.netfx.cs
@@ -1,0 +1,126 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\QueryEnumerableParams.input.cs", 20, 20)]
+        internal static int Execute0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Execute, HasParameters, Text, KnownParameters
+            // takes parameter: global::System.Collections.Generic.List<global::Foo.Customer>
+            // parameter map: X
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.Text, commandTimeout.GetValueOrDefault(), CommandFactory0.Instance).Execute((global::System.Collections.Generic.List<global::Foo.Customer>)param!);
+
+        }
+
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\QueryEnumerableParams.input.cs", 21, 20)]
+        internal static int Execute1(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Execute, HasParameters, Text, KnownParameters
+            // takes parameter: global::<anonymous type: int Id>[]
+            // parameter map: Id
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.Text);
+            global::System.Diagnostics.Debug.Assert(param is not null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.Text, commandTimeout.GetValueOrDefault(), CommandFactory1.Instance).Execute((object?[])param!);
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class CommandFactory0 : CommonCommandFactory<global::Foo.Customer>
+        {
+            internal static readonly CommandFactory0 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.Customer args)
+            {
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "X";
+                p.DbType = global::System.Data.DbType.Int32;
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                p.Value = AsValue(args.X);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, global::Foo.Customer args)
+            {
+                var ps = cmd.Parameters;
+                ps[0].Value = AsValue(args.X);
+
+            }
+            public override bool CanPrepare => true;
+
+        }
+
+        private sealed class CommandFactory1 : CommonCommandFactory<object?> // <anonymous type: int Id>
+        {
+            internal static readonly CommandFactory1 Instance = new();
+            public override void AddParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Id = default(int) }); // expected shape
+                var ps = cmd.Parameters;
+                global::System.Data.Common.DbParameter p;
+                p = cmd.CreateParameter();
+                p.ParameterName = "Id";
+                p.DbType = global::System.Data.DbType.Int32;
+                p.Direction = global::System.Data.ParameterDirection.Input;
+                p.Value = AsValue(typed.Id);
+                ps.Add(p);
+
+            }
+            public override void UpdateParameters(in global::Dapper.UnifiedCommand cmd, object? args)
+            {
+                var typed = Cast(args, static () => new { Id = default(int) }); // expected shape
+                var ps = cmd.Parameters;
+                ps[0].Value = AsValue(typed.Id);
+
+            }
+            public override bool CanPrepare => true;
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 0 readers


### PR DESCRIPTION
An enumerable parameter means multi-exec, which only exists for `Execute`; vanilla Dapper throws for every other operation (*"An enumerable sequence of parameters ... is not allowed in this context"*). The generator had no such check, so `Query` with a collection parameter fell into the single-parameter path and generated a command over the collection's own members — and when the element type was anonymous, it emitted the type's *display string* into source (`CommandFactory<global::<anonymous type: ...>[]>`), whose angle brackets broke the parse of the whole generated file, cascading into ~90 downstream errors.

I found this by enabling Dapper.AOT across the Dapper test suite: `SO30435185_InvalidTypeOwner` passes an array of anonymous types to `Query` and asserts the vanilla throw.

Fix: in the shared parameter checks, mark collection-parameter call-sites outside plain `Execute` as do-not-generate, so they stay on vanilla Dapper and the documented throw still happens. Multi-exec on `Execute` — including anonymous element types, which already use the `object?`/`Cast` witness shape — is unchanged, and the new golden fixture pins both halves. Verified the fixture fails without the fix; full unit suite green on net8.0/net10.0/net48.