### PR TITLE
Check parameter member types, not just the parameter type

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -735,6 +735,30 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                     // generating a command over the collection's own members
                     flags |= OperationFlags.DoNotGenerate;
                 }
+
+                if (!flags.HasAny(OperationFlags.DoNotGenerate))
+                {
+                    // the *member* types get named in the generated code too (for example in the
+                    // anonymous-type shape witness), so they need the same checks as the parameter
+                    // type itself; note for multi-exec the members come from the element type
+                    var memberHost = IsCollectionType(paramType, out var elementType) ? elementType : paramType;
+                    foreach (var member in GetMembers(forParameters: true, memberHost, null, null))
+                    {
+                        if (member.CodeType is not { } memberType) continue;
+                        if (InvolvesGenericTypeParameter(memberType))
+                        {
+                            flags |= OperationFlags.DoNotGenerate;
+                            reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.GenericTypeParameter, argLocation, memberType.ToDisplayString()));
+                            break;
+                        }
+                        if (!IsPublicOrAssemblyLocal(memberType, ctx, out var failingMember))
+                        {
+                            flags |= OperationFlags.DoNotGenerate;
+                            reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.NonPublicType, argLocation, failingMember!.ToDisplayString(), NameAccessibility(failingMember)));
+                            break;
+                        }
+                    }
+                }
             }
         }
         return callLocation;

--- a/test/Dapper.AOT.Test/Verifiers/DAP016.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP016.cs
@@ -31,4 +31,22 @@ public class DAP016 : Verifier<DapperAnalyzer>
             Diagnostic(Diagnostics.GenericTypeParameter).WithLocation(1).WithArguments("TY"),
             Diagnostic(Diagnostics.GenericTypeParameter).WithLocation(2).WithArguments("TZ")]);
 
+    [Fact] // a member *type* that involves the container's type parameter is just as unusable
+    public Task GenericTypeParameterViaMember() => CSVerifyAsync("""
+        using Dapper;
+        using System.Data.Common;
+
+        [DapperAot]
+        class GenericType<TX>
+        {
+            public class Nested { public int Id {get;set;} }
+
+            // Nested means GenericType<TX>.Nested, which generated code cannot name
+            void ViaAnonymousMember(DbConnection conn, Nested value) => conn.Execute("somesql", {|#0:new { value }|});
+            void ViaPocoIsFine(DbConnection conn, Poco args) => conn.Execute("somesql", args);
+        }
+        class Poco { public int Id {get;set;} }
+        """, DefaultConfig, [
+            Diagnostic(Diagnostics.GenericTypeParameter).WithLocation(0).WithArguments("GenericType<TX>.Nested")]);
+
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP017.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP017.cs
@@ -95,4 +95,23 @@ public class DAP017 : Verifier<DapperAnalyzer>
             Diagnostic(Diagnostics.NonPublicType).WithLocation(10).WithArguments("NestedInternal.InnerPrivate", "private"),
             Diagnostic(Diagnostics.NonPublicType).WithLocation(11).WithArguments("NestedInternal.InnerPrivateStruct", "private"),
     ]);
+
+    [Fact] // member types are named in generated code (e.g. the anonymous-type shape witness)
+    public Task NonPublicMemberType() => CSVerifyAsync("""
+        using Dapper;
+        using System.Data.Common;
+
+        internal class HasPrivateMember
+        {
+            [DapperAot]
+            class AotEnabled
+            {
+                void ViaAnonymous(DbConnection conn, Inner value) => conn.Execute("somesql", {|#0:new { value }|});
+                void PublicMemberIsFine(DbConnection conn, int value) => conn.Execute("somesql", new { value });
+            }
+            private class Inner { public int Id {get;set;} }
+        }
+        """, DefaultConfig, [
+            Diagnostic(Diagnostics.NonPublicType).WithLocation(0).WithArguments("HasPrivateMember.Inner", "private"),
+    ]);
 }


### PR DESCRIPTION
The parameter object's own type gets checked for generic type parameters (DAP016) and accessibility (DAP017), but its *member* types do not — and those are named in the generated code too, most visibly in the anonymous-type shape witness (`Cast(args, static () => new { x = default(TheMemberType) })`).

Found via the Dapper test suite: `ParameterTests<TProvider>` passes `new { integers = new IntCustomParam(...) }`, and the generated witness read `default(global::Dapper.Tests.ParameterTests<TProvider>.IntCustomParam)` — an open type parameter *and* a private nested type, neither nameable from the generated file (CS0246 + CS0122).

Fix: after the existing parameter-type checks, run the same two checks over the bound members (using the element type for multi-exec), reporting DAP016/DAP017 at the argument. New verifier cases on both rules fail without the fix; full unit suite green (261).