### PR TITLE
RowFactory.GetRowParser: accept IDataReader

### DIFF
--- a/src/Dapper.AOT/RowFactory.cs
+++ b/src/Dapper.AOT/RowFactory.cs
@@ -281,6 +281,25 @@ public class RowFactory<T> : RowFactory
         return state.Parse;
     }
 
+    /// <summary>
+    /// Gets the row parser for a specific row on a data reader. This allows for type switching every row based on, for example, a TypeId column.
+    /// You could return a collection of the base type but have each more specific.
+    /// </summary>
+    /// <param name="reader">The data reader to get the parser for the current row from; this must be a <see cref="DbDataReader"/>.</param>
+    /// <param name="startIndex">The start column index of the object (default: 0).</param>
+    /// <param name="length">The length of columns to read (default: -1 = all fields following startIndex).</param>
+    /// <param name="returnNullIfFirstMissing">Return null if the value of the first column is <c>null</c>.</param>
+    /// <returns>A parser for this specific object from this row.</returns>
+    public Func<IDataReader, T> GetRowParser(IDataReader reader,
+            int startIndex = 0, int length = -1, bool returnNullIfFirstMissing = false)
+    {
+        var typed = GetRowParser(AsDbDataReader(reader), startIndex, length, returnNullIfFirstMissing);
+        return r => typed(AsDbDataReader(r));
+
+        static DbDataReader AsDbDataReader(IDataReader reader) => reader as DbDataReader
+            ?? throw new ArgumentException("A DbDataReader is required", nameof(reader));
+    }
+
     private abstract class RowParserState
     {
         // manual capture state for row reader; initialized with tokenized column metadata, then

--- a/test/Dapper.AOT.Test/RowFactoryReaderTests.cs
+++ b/test/Dapper.AOT.Test/RowFactoryReaderTests.cs
@@ -1,0 +1,71 @@
+using Dapper;
+using System;
+using System.Data;
+using Xunit;
+
+namespace Dapper.AOT.Test;
+
+public class RowFactoryReaderTests
+{
+    private static DataTableReader CreateReader()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Value", typeof(int));
+        table.Rows.Add(42);
+        return table.CreateDataReader();
+    }
+
+    [Fact]
+    public void GetRowParser_IDataReader_WorksForDbDataReader()
+    {
+        using var reader = CreateReader();
+        Assert.True(reader.Read());
+        var parser = RowFactory.Inbuilt.Value<int>().GetRowParser((IDataReader)reader);
+        Assert.Equal(42, parser(reader));
+    }
+
+    [Fact]
+    public void GetRowParser_IDataReader_ThrowsForNonDbDataReader()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => RowFactory.Inbuilt.Value<int>().GetRowParser(new NotADbDataReader()));
+        Assert.Equal("reader", ex.ParamName);
+    }
+
+    private sealed class NotADbDataReader : IDataReader
+    {
+        public object this[int i] => throw new NotSupportedException();
+        public object this[string name] => throw new NotSupportedException();
+        public int Depth => 0;
+        public bool IsClosed => false;
+        public int RecordsAffected => 0;
+        public int FieldCount => 0;
+        public void Close() { }
+        public void Dispose() { }
+        public bool GetBoolean(int i) => throw new NotSupportedException();
+        public byte GetByte(int i) => throw new NotSupportedException();
+        public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => throw new NotSupportedException();
+        public char GetChar(int i) => throw new NotSupportedException();
+        public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => throw new NotSupportedException();
+        public IDataReader GetData(int i) => throw new NotSupportedException();
+        public string GetDataTypeName(int i) => throw new NotSupportedException();
+        public DateTime GetDateTime(int i) => throw new NotSupportedException();
+        public decimal GetDecimal(int i) => throw new NotSupportedException();
+        public double GetDouble(int i) => throw new NotSupportedException();
+        public Type GetFieldType(int i) => throw new NotSupportedException();
+        public float GetFloat(int i) => throw new NotSupportedException();
+        public Guid GetGuid(int i) => throw new NotSupportedException();
+        public short GetInt16(int i) => throw new NotSupportedException();
+        public int GetInt32(int i) => throw new NotSupportedException();
+        public long GetInt64(int i) => throw new NotSupportedException();
+        public string GetName(int i) => throw new NotSupportedException();
+        public int GetOrdinal(string name) => throw new NotSupportedException();
+        public DataTable? GetSchemaTable() => null;
+        public string GetString(int i) => throw new NotSupportedException();
+        public object GetValue(int i) => throw new NotSupportedException();
+        public int GetValues(object[] values) => throw new NotSupportedException();
+        public bool IsDBNull(int i) => throw new NotSupportedException();
+        public bool NextResult() => false;
+        public bool Read() => false;
+    }
+}


### PR DESCRIPTION
Dapper's `GetRowParser<T>` extension is declared on `IDataReader`, so the interceptor's forwarding call passes an `IDataReader` to `RowFactory<T>.GetRowParser(DbDataReader, ...)` — CS1503 in the consumer's build; the returned delegate types don't convert either, since `Func<DbDataReader,T>` → `Func<IDataReader,T>` is the wrong direction for contravariance. Found via the Dapper test suite (`DataReaderTests`).

Fix on the runtime side: an `IDataReader` overload that unwraps to `DbDataReader` — throwing `ArgumentException` for non-Db readers, which in practice don't arise: every reader Dapper itself produces (`DbWrappedReader`, `WrappedBasicReader`, provider readers) derives from `DbDataReader` — and wraps the parser delegate the same way. Generated code is unchanged; overload resolution picks the right overload from the receiver's static type. Unit tests cover both the working path (via `DataTableReader`) and the throwing one; full unit suite green on net10.0, net48 builds clean.