### PR TITLE
Refuse result types the generated code cannot construct (DAP050)

### DIFF
--- a/docs/rules/DAP050.md
+++ b/docs/rules/DAP050.md
@@ -1,0 +1,18 @@
+# DAP050
+
+Result type cannot be constructed
+
+The generated materializer needs a way to create an instance of the result type: an accessible
+parameterless constructor, or a single usable constructor (or `[ExplicitConstructor]`, or a
+factory method) whose parameters correspond to the type's members. This type has none of those,
+so Dapper.AOT leaves the call-site on vanilla Dapper - which may work there via runtime
+configuration such as type handlers (`SqlMapper.AddTypeHandler`), but that mechanism is not
+available to AOT-generated code.
+
+Examples of types that hit this: `System.Data.Entity.Spatial.DbGeography` (no accessible
+constructor; vanilla uses type handlers from *Dapper.EntityFramework*), and
+`System.Data.Linq.Binary` (only a `byte[]` constructor, which does not correspond to a member).
+
+To use such a type with Dapper.AOT: give the type an accessible parameterless constructor or a
+suitable constructor/factory method, or use a different type for the query and convert
+afterwards.

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.Diagnostics.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.Diagnostics.cs
@@ -56,6 +56,7 @@ partial class DapperAnalyzer
         AmbiguousProperties = LibraryWarning("DAP046", "Ambiguous properties", "Properties have same name '{0}' after normalization and can be conflated"),
         AmbiguousFields = LibraryWarning("DAP047", "Ambiguous fields", "Fields have same name '{0}' after normalization and can be conflated"),
         MoveFromDbString = LibraryWarning("DAP048", "Move from DbString to DbValue", "DbString achieves the same as [DbValue] does. Use it instead."),
+        UnconstructableResultType = LibraryWarning("DAP050", "Result type cannot be constructed", "Type '{0}' cannot be constructed by generated code; it needs an accessible parameterless constructor, or a constructor/factory method whose parameters match its members"),
         UnableToBindQueryColumns = LibraryError("DAP049", "Unable to bind query columns", "Something went terribly wrong"),
 
         // SQL parse specific

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -665,6 +665,16 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        if (!flags.HasAny(OperationFlags.DoNotGenerate)
+            && flags.HasAny(OperationFlags.Query | OperationFlags.GetRowParser)
+            && IsUnconstructableResultType(resultType, ctx.SemanticModel.Compilation.Assembly))
+        {
+            // the emitted row factory could not create the instance (this is what vanilla Dapper
+            // handles via runtime type-handlers etc); leave the call-site alone
+            flags |= OperationFlags.DoNotGenerate;
+            reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.UnconstructableResultType, callLocation, resultType!.ToDisplayString()));
+        }
+
         if (flags.HasAny(OperationFlags.Query) && (IsEnabled(ctx, op, Types.StrictTypesAttribute, out _)))
         {
             flags |= OperationFlags.StrictTypes;

--- a/src/Dapper.AOT.Analyzers/Internal/CodeWriter.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/CodeWriter.cs
@@ -330,7 +330,7 @@ internal sealed class CodeWriter
 
     internal CodeWriter AppendReader(ITypeSymbol? resultType, RowReaderState readers, OperationFlags flags, ImmutableArray<string> queryColumns)
     {
-        if (IsInbuilt(resultType, out var helper))
+        if (IsInbuiltResultType(resultType, out var helper))
         {
             return Append("global::Dapper.RowFactory.Inbuilt.").Append(helper);
         }
@@ -338,8 +338,9 @@ internal sealed class CodeWriter
         {
             return Append("RowFactory").Append(readers.GetIndex(resultType!, flags, queryColumns)).Append(".Instance");
         }
+    }
 
-        static bool IsInbuilt(ITypeSymbol? type, out string? helper)
+    internal static bool IsInbuiltResultType(ITypeSymbol? type, out string? helper)
         {
             if (type is null || type.TypeKind == TypeKind.Dynamic)
             {
@@ -405,7 +406,5 @@ internal sealed class CodeWriter
             }
             helper = null;
             return false;
-
-        }
     }
 }

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -745,6 +745,67 @@ internal static class Inspection
         }
     }
 
+    /// <summary>
+    /// Mirrors the row-factory emitter's construction decision: is there any way the generated
+    /// code can create an instance of this result type? (structs and inbuilt row types always can)
+    /// </summary>
+    internal static bool IsUnconstructableResultType(ITypeSymbol? resultType, IAssemblySymbol? assembly)
+    {
+        if (resultType is not INamedTypeSymbol named || named.IsValueType) return false;
+        if (CodeWriter.IsInbuiltResultType(named, out _)) return false;
+        var map = MemberMap.CreateForResults(named);
+        if (map is null) return false;
+
+        if (map.Constructor is { } ctor)
+        {   // the emitter passes an argument per member carrying ConstructorParameterOrder;
+            // if the constructor demands more, the emitted call will not compile
+            return CountMapped(map, factory: false) < RequiredParameterCount(ctor);
+        }
+        if (map.FactoryMethod is { } factoryMethod)
+        {
+            return CountMapped(map, factory: true) < RequiredParameterCount(factoryMethod);
+        }
+        // otherwise the emitter emits parameterless construction: new T() / new T { ... }
+        if (named.IsAbstract || named.TypeKind == TypeKind.Interface) return true;
+        foreach (var candidate in named.InstanceConstructors)
+        {
+            if (!candidate.Parameters.IsEmpty) continue;
+            switch (candidate.DeclaredAccessibility)
+            {
+                case Accessibility.Public:
+                    return false;
+                case Accessibility.Internal:
+                case Accessibility.ProtectedOrInternal:
+                    if (assembly is not null && SymbolEqualityComparer.Default.Equals(candidate.ContainingAssembly, assembly))
+                    {
+                        return false;
+                    }
+                    break;
+            }
+        }
+        return true;
+
+        static int CountMapped(MemberMap map, bool factory)
+        {
+            int count = 0;
+            foreach (var member in map.Members)
+            {
+                if (!member.IsMapped) continue;
+                if ((factory ? member.FactoryMethodParameterOrder : member.ConstructorParameterOrder) is not null) count++;
+            }
+            return count;
+        }
+        static int RequiredParameterCount(IMethodSymbol method)
+        {
+            int count = 0;
+            foreach (var p in method.Parameters)
+            {
+                if (!p.IsOptional) count++;
+            }
+            return count;
+        }
+    }
+
     public enum ConstructorResult
     {
         NoneFound,

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.input.cs
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.input.cs
@@ -1,0 +1,24 @@
+using Dapper;
+using System.Data.Common;
+
+[module: DapperAot]
+
+public static class Foo
+{
+    static void SomeCode(DbConnection connection)
+    {
+        // like EF's DbGeography: no accessible parameterless constructor, but has a settable member
+        _ = connection.Query<PrivateCtor>("select_sql");
+        // like System.Data.Linq.Binary: only a parameterized constructor, no settable members
+        _ = connection.Query<BinaryLike>("select_sql");
+        // abstract types cannot be constructed at all
+        _ = connection.Query<AbstractType>("select_sql");
+        // control: an ordinary POCO still works
+        _ = connection.Query<Poco>("select_sql");
+    }
+
+    public class PrivateCtor { private PrivateCtor() { } public int Value { get; set; } }
+    public class BinaryLike { public BinaryLike(byte[] value) { } public int Length => 0; }
+    public abstract class AbstractType { public int Value { get; set; } }
+    public class Poco { public int Value { get; set; } }
+}

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.cs
@@ -1,0 +1,108 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\UnconstructableResults.input.cs", 17, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<global::Foo.Poco> Query0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, Buffered, StoredProcedure, BindResultsByName
+            // returns data: global::Foo.Poco
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), DefaultCommandFactory).QueryBuffered(param, RowFactory0.Instance);
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class RowFactory0 : global::Dapper.RowFactory<global::Foo.Poco>
+        {
+            internal static readonly RowFactory0 Instance = new();
+            private RowFactory0() {}
+            public override object? Tokenize(global::System.Data.Common.DbDataReader reader, global::System.Span<int> tokens, int columnOffset)
+            {
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    int token = -1;
+                    var name = reader.GetName(columnOffset);
+                    var type = reader.GetFieldType(columnOffset);
+                    switch (NormalizedHash(name))
+                    {
+                        case 1113510858U when NormalizedEquals(name, "value"):
+                            token = type == typeof(int) ? 0 : 1; // two tokens for right-typed and type-flexible
+                            break;
+
+                    }
+                    tokens[i] = token;
+                    columnOffset++;
+
+                }
+                return null;
+            }
+            public override global::Foo.Poco Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)
+            {
+                global::Foo.Poco result = new();
+                foreach (var token in tokens)
+                {
+                    switch (token)
+                    {
+                        case 0:
+                            result.Value = reader.GetInt32(columnOffset);
+                            break;
+                        case 1:
+                            result.Value = GetValue<int>(reader, columnOffset);
+                            break;
+
+                    }
+                    columnOffset++;
+
+                }
+                return result;
+
+            }
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.netfx.cs
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.netfx.cs
@@ -1,0 +1,108 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\UnconstructableResults.input.cs", 17, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<global::Foo.Poco> Query0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, Buffered, StoredProcedure, BindResultsByName
+            // returns data: global::Foo.Poco
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), DefaultCommandFactory).QueryBuffered(param, RowFactory0.Instance);
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class RowFactory0 : global::Dapper.RowFactory<global::Foo.Poco>
+        {
+            internal static readonly RowFactory0 Instance = new();
+            private RowFactory0() {}
+            public override object? Tokenize(global::System.Data.Common.DbDataReader reader, global::System.Span<int> tokens, int columnOffset)
+            {
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    int token = -1;
+                    var name = reader.GetName(columnOffset);
+                    var type = reader.GetFieldType(columnOffset);
+                    switch (NormalizedHash(name))
+                    {
+                        case 1113510858U when NormalizedEquals(name, "value"):
+                            token = type == typeof(int) ? 0 : 1; // two tokens for right-typed and type-flexible
+                            break;
+
+                    }
+                    tokens[i] = token;
+                    columnOffset++;
+
+                }
+                return null;
+            }
+            public override global::Foo.Poco Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)
+            {
+                global::Foo.Poco result = new();
+                foreach (var token in tokens)
+                {
+                    switch (token)
+                    {
+                        case 0:
+                            result.Value = reader.GetInt32(columnOffset);
+                            break;
+                        case 1:
+                            result.Value = GetValue<int>(reader, columnOffset);
+                            break;
+
+                    }
+                    columnOffset++;
+
+                }
+                return result;
+
+            }
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Verifiers/DAP035.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP035.cs
@@ -19,7 +19,7 @@ public class DAP035 : Verifier<DapperAnalyzer>
             {
                 _ = conn.Query<NoConstructors>("storedproc");
                 _ = conn.Query<SingleExplicit>("storedproc");
-                _ = conn.Query<MultipleExplicit>("storedproc");
+                _ = conn.{|#1:Query<MultipleExplicit>|}("storedproc");
             }
         }
         class NoConstructors { public int Id {get;set;} }
@@ -40,6 +40,7 @@ public class DAP035 : Verifier<DapperAnalyzer>
         }
         """, DefaultConfig, [
             Diagnostic(Diagnostics.ConstructorMultipleExplicit).WithLocation(0).WithArguments("MultipleExplicit"),
+            Diagnostic(Diagnostics.UnconstructableResultType).WithLocation(1).WithArguments("MultipleExplicit"),
     ]);
 
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP036.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP036.cs
@@ -20,7 +20,7 @@ public class DAP036 : Verifier<DapperAnalyzer>
             {
                 _ = conn.Query<NoConstructors>("storedproc");
                 _ = conn.Query<SingleImplicit>("storedproc");
-                _ = conn.Query<MultipleImplicit>("storedproc");
+                _ = conn.{|#1:Query<MultipleImplicit>|}("storedproc");
 
                 _ = conn.Query<RecordClass>("storedproc");
                 _ = conn.Query<RecordStruct>("storedproc");
@@ -60,6 +60,7 @@ public class DAP036 : Verifier<DapperAnalyzer>
         }
         """, DefaultConfig, [
             Diagnostic(Diagnostics.ConstructorAmbiguous).WithLocation(0).WithArguments("MultipleImplicit"),
+            Diagnostic(Diagnostics.UnconstructableResultType).WithLocation(1).WithArguments("MultipleImplicit"),
     ]);
 
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP037.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP037.cs
@@ -79,6 +79,7 @@ public class DAP037 : Verifier<DapperAnalyzer>
         }
         """", DefaultConfig, [
             Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(0).WithArguments("NoSettable"),
+            Diagnostic(Diagnostics.UnconstructableResultType).WithLocation(0).WithArguments("NoSettable"),
             Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(1).WithArguments("ReadOnlyField"),
             Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(2).WithArguments(""),
     ]);

--- a/test/Dapper.AOT.Test/Verifiers/DAP050.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP050.cs
@@ -1,0 +1,46 @@
+using Dapper.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+using static Dapper.CodeAnalysis.DapperAnalyzer;
+
+namespace Dapper.AOT.Test.Verifiers;
+
+public class DAP050 : Verifier<DapperAnalyzer>
+{
+    [Fact]
+    public Task UnconstructableResultType() => CSVerifyAsync("""
+        using Dapper;
+        using System.Data.Common;
+
+        [DapperAot]
+        class SomeCode
+        {
+            void Queries(DbConnection conn)
+            {
+                // no accessible parameterless constructor (like EF's DbGeography)
+                _ = conn.{|#0:Query<PrivateCtor>|}("somesql");
+                // only a parameterized constructor whose parameter matches no member (like System.Data.Linq.Binary)
+                _ = conn.{|#1:Query<BinaryLike>|}("somesql");
+                // abstract types cannot be constructed at all
+                _ = conn.{|#2:Query<AbstractType>|}("somesql");
+                // fine: ordinary POCO
+                _ = conn.Query<Poco>("somesql");
+                // fine: constructor parameters correspond to members
+                _ = conn.Query<UsableCtor>("somesql");
+                // fine: structs need no constructor
+                _ = conn.Query<SomeStruct>("somesql");
+            }
+        }
+        public class PrivateCtor { private PrivateCtor() { } public int Value {get;set;} }
+        public class BinaryLike { public BinaryLike(byte[] value) { } public int Length => 0; }
+        public abstract class AbstractType { public int Value {get;set;} }
+        public class Poco { public int Value {get;set;} }
+        public class UsableCtor { public UsableCtor(int value) { Value = value; } public int Value { get; } }
+        public struct SomeStruct { public int Value {get;set;} }
+        """, DefaultConfig, [
+            Diagnostic(Diagnostics.UnconstructableResultType).WithLocation(0).WithArguments("PrivateCtor"),
+            Diagnostic(Diagnostics.UnconstructableResultType).WithLocation(1).WithArguments("BinaryLike"),
+            Diagnostic(Diagnostics.UserTypeNoSettableMembersFound).WithLocation(1).WithArguments("BinaryLike"),
+            Diagnostic(Diagnostics.UnconstructableResultType).WithLocation(2).WithArguments("AbstractType"),
+    ]);
+}


### PR DESCRIPTION
The row-factory emitter has three construction forms — parameterless `new()`, chosen constructor, factory method — and none was validated at parse time. Found via the Dapper test suite's net481 leg:

- `Query<DbGeography>` / `Query<DbGeometry>` (EF spatial): no accessible constructor → emitted `new()` → CS1729/CS0122
- `Query<System.Data.Linq.Binary>`: only a `byte[]` constructor whose parameter matches no member → emitted a zero-argument constructor call → CS7036
- abstract types → CS0144

Vanilla handles all of these via runtime type handlers (e.g. *Dapper.EntityFramework*), which generated code cannot use — so the right behavior today is a refusal that leaves the call-site on vanilla.

The new shared check mirrors the emitter's decision exactly: with a chosen constructor/factory, every *required* parameter must be covered by a mapped member; otherwise a non-abstract type with an accessible parameterless constructor is required. Structs always pass; inbuilt row types (scalars, `dynamic`, `object`, `IDataRecord`…) are exempt via the same `IsInbuilt` gate the emitter uses (hoisted from `AppendReader` so parse can share it). Refused sites get new **warning DAP050** (docs included).

The DAP035/036/037 verifiers now also expect DAP050 where the shape is genuinely unconstructable — that co-report is load-bearing: those existing *errors* never actually stopped generation, so the refusal here is what prevents the broken emit. New golden fixture (`UnconstructableResults`) pins all three refusal shapes plus POCO/ctor/struct controls; new DAP050 verifier; full unit suite green (269).