### PR TITLE
Make the DAP000 scorecard honest

### DIFF
--- a/docs/rules/DAP000.md
+++ b/docs/rules/DAP000.md
@@ -1,3 +1,18 @@
-﻿# DAP000
+# DAP000
 
 This message is mostly for debugging and monitoring. But hey, the generator is at least loading, so; yay, I guess?
+
+The counts read:
+
+> handled {X} of {Y} enabled call-sites ({A} unsupported API, {B} skipped due to diagnostics) ...
+
+- **enabled call-sites**: every Dapper call-site where Dapper.AOT is enabled (`[DapperAot]`),
+  whether or not it could be handled - so `Y = X + A + B`, and 100% means what it says;
+- **unsupported API**: calls to Dapper APIs that Dapper.AOT does not (yet) implement, for
+  example `QueryMultiple` or the multi-map `Query` overloads; these stay on vanilla Dapper;
+- **skipped due to diagnostics**: calls Dapper.AOT understands but declines, for a reason
+  reported as a separate diagnostic (for example DAP016/DAP017/DAP050); these also stay on
+  vanilla Dapper.
+
+Note that "handled" is a build-time statement: the call is intercepted and compiles. Whether
+it *behaves* identically is what your tests are for.

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Diagnostics.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Diagnostics.cs
@@ -8,7 +8,7 @@ partial class DapperInterceptorGenerator
     {
 
         internal static readonly DiagnosticDescriptor
-            InterceptorsGenerated = LibraryHidden("DAP000", "Interceptors generated", "Dapper.AOT handled {0} of {1} possible call-sites using {2} interceptors, {3} commands and {4} readers"),
+            InterceptorsGenerated = LibraryHidden("DAP000", "Interceptors generated", "Dapper.AOT handled {0} of {1} enabled call-sites ({2} unsupported API, {3} skipped due to diagnostics) using {4} interceptors, {5} commands and {6} readers"),
             LanguageVersionTooLow = LibraryWarning("DAP004", "Language version too low", "Interceptors require at least C# version 11"),
 
             CommandPropertyNotFound = LibraryWarning("DAP033", "Command property not found", "Command property {0}.{1} was not found or was not valid; attribute will be ignored"),

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -98,16 +98,22 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             if (ctx.Node is not InvocationExpressionSyntax ie
                 || ctx.SemanticModel.GetOperation(ie) is not IInvocationOperation op
                 || !op.IsDapperMethod(out var flags)
-                || flags.HasAny(OperationFlags.NotAotSupported | OperationFlags.DoNotGenerate)
+                || flags.HasAny(OperationFlags.DoNotGenerate)
                 || !Inspection.IsEnabled(ctx, op, Types.DapperAotAttribute, out var aotAttribExists))
             {
                 return null;
+            }
+            if (flags.HasAny(OperationFlags.NotAotSupported))
+            {
+                // not our API (yet); count it, so the scorecard stays honest
+                return new SkippedSourceState(ie.GetLocation(), flags);
             }
 
             var location = DapperAnalyzer.SharedParseArgsAndFlags(ctx, op, ref flags, out var sql, out var argExpression, reportDiagnostic: null, out var resultType, exitFirstFailure: true);
             if (flags.HasAny(OperationFlags.DoNotGenerate))
             {
-                return null;
+                // diagnostics (from the analyzer's identical pass) told us to leave it alone
+                return new SkippedSourceState(location, flags);
             }
 
 
@@ -262,9 +268,22 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             ctx.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnknownError, fault.Location, ex.Message, ex.StackTrace));
         }
 
+        int unsupported = 0, skippedViaDiagnostics = 0;
+        foreach (var skip in ctx.Nodes.OfType<SkippedSourceState>())
+        {
+            if (skip.Flags.HasAny(OperationFlags.NotAotSupported)) unsupported++;
+            else skippedViaDiagnostics++;
+        }
+
         if (!CheckPrerequisites(ctx)) // also reports per-item diagnostics
         {
-            // failed checks; do nothing
+            // failed checks; nothing to generate, but still say what we saw - and every
+            // enabled call-site (including ones we *could* have handled) goes unhandled
+            if (!ctx.Nodes.IsDefaultOrEmpty)
+            {
+                int total = unsupported + skippedViaDiagnostics + ctx.Nodes.OfType<SuccessSourceState>().Count();
+                ctx.ReportDiagnostic(Diagnostic.Create(Diagnostics.InterceptorsGenerated, null, 0, total, unsupported, skippedViaDiagnostics, 0, 0, 0));
+            }
             return;
         }
 
@@ -468,7 +487,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         preGeneratedCodeWriter.Write(ctx.GeneratorContext.IncludedGenerationTypes);
 
         ctx.AddSource((ctx.Compilation.AssemblyName ?? "package") + ".generated.cs", sb.ToString());
-        ctx.ReportDiagnostic(Diagnostic.Create(Diagnostics.InterceptorsGenerated, null, callSiteCount, ctx.Nodes.Length, methodIndex, factories.Count(), readers.Count()));
+        ctx.ReportDiagnostic(Diagnostic.Create(Diagnostics.InterceptorsGenerated, null,
+            callSiteCount, callSiteCount + unsupported + skippedViaDiagnostics, unsupported, skippedViaDiagnostics,
+            methodIndex, factories.Count(), readers.Count()));
     }
 
     private static void WriteGetRowParser(CodeWriter sb, ITypeSymbol? resultType, in RowReaderState readers, OperationFlags flags, ImmutableArray<string> queryColumns)
@@ -1492,6 +1513,16 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
     {
         public Location? Location { get; }
         protected SourceState(Location? location) => Location = location;
+    }
+
+    internal sealed class SkippedSourceState : SourceState
+    {
+        // a call-site that Dapper.AOT is *not* handling - either the API is not supported at
+        // all, or diagnostics made us leave it alone; retained so the DAP000 scorecard can
+        // count honestly rather than quietly shrinking the denominator
+        public OperationFlags Flags { get; }
+        public SkippedSourceState(Location? location, OperationFlags flags) : base(location)
+            => Flags = flags;
     }
 
     internal sealed class FaultSourceState : SourceState

--- a/test/Dapper.AOT.Test/Interceptors/BaseCommandFactory.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/BaseCommandFactory.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/BaseCommandFactory.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/BaseCommandFactory.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/BatchSize.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/BatchSize.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/BatchSize.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/BatchSize.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/Blame.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Blame.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 23 of 23 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 23 of 23 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/Blame.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Blame.output.txt
@@ -5,7 +5,7 @@ Warning CS0618 Interceptors/Blame.input.cs L8 C28
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 23 of 23 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 23 of 23 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers
 Output code has 1 diagnostics from 'Interceptors/Blame.input.cs':
 
 Warning CS0618 Interceptors/Blame.input.cs L8 C28

--- a/test/Dapper.AOT.Test/Interceptors/CacheCommand.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/CacheCommand.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 4 of 4 possible call-sites using 4 interceptors, 6 commands and 0 readers
+Dapper.AOT handled 4 of 4 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 6 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/CacheCommand.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/CacheCommand.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 4 of 4 possible call-sites using 4 interceptors, 6 commands and 0 readers
+Dapper.AOT handled 4 of 4 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 6 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/Cancellation.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Cancellation.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/Cancellation.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Cancellation.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/ColumnAttribute.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ColumnAttribute.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/ColumnAttribute.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ColumnAttribute.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/CommandProperties.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/CommandProperties.output.netfx.txt
@@ -1,7 +1,7 @@
 Generator produced 3 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 6 of 6 possible call-sites using 5 interceptors, 7 commands and 1 readers
+Dapper.AOT handled 6 of 6 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 5 interceptors, 7 commands and 1 readers
 
 Warning DAP033 Interceptors/CommandProperties.input.cs L12 C17
 Command property SqlCommand.InvalidName was not found or was not valid; attribute will be ignored

--- a/test/Dapper.AOT.Test/Interceptors/CommandProperties.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/CommandProperties.output.txt
@@ -1,7 +1,7 @@
 Generator produced 3 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 6 of 6 possible call-sites using 5 interceptors, 7 commands and 1 readers
+Dapper.AOT handled 6 of 6 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 5 interceptors, 7 commands and 1 readers
 
 Warning DAP033 Interceptors/CommandProperties.input.cs L12 C17
 Command property SqlCommand.InvalidName was not found or was not valid; attribute will be ignored

--- a/test/Dapper.AOT.Test/Interceptors/ComplexGenerics.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ComplexGenerics.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 0 of 2 enabled call-sites (0 unsupported API, 2 skipped due to diagnostics) using 0 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/ComplexGenerics.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ComplexGenerics.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 0 of 2 enabled call-sites (0 unsupported API, 2 skipped due to diagnostics) using 0 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/DateOnly.net6.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DateOnly.net6.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/DbString.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DbString.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/DbString.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DbString.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/DbValueUsage.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DbValueUsage.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/DbValueUsage.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DbValueUsage.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/EnumerableExtensions.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/EnumerableExtensions.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 6 of 6 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 6 of 6 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/EnumerableExtensions.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/EnumerableExtensions.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 6 of 6 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 6 of 6 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/Execute.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Execute.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 6 of 6 possible call-sites using 6 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 6 of 6 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 6 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/Execute.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Execute.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 6 of 6 possible call-sites using 6 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 6 of 6 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 6 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/ExecuteBatch.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ExecuteBatch.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 9 of 9 possible call-sites using 9 interceptors, 3 commands and 0 readers
+Dapper.AOT handled 9 of 9 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 9 interceptors, 3 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/ExecuteBatch.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ExecuteBatch.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 9 of 9 possible call-sites using 9 interceptors, 3 commands and 0 readers
+Dapper.AOT handled 9 of 9 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 9 interceptors, 3 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/ExecuteScalar.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ExecuteScalar.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 12 of 12 possible call-sites using 12 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 12 of 12 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 12 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/ExecuteScalar.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/ExecuteScalar.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 12 of 12 possible call-sites using 12 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 12 of 12 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 12 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/GetRowParser.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/GetRowParser.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 2 of 4 enabled call-sites (1 unsupported API, 1 skipped due to diagnostics) using 2 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/GetRowParser.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/GetRowParser.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 2 of 4 enabled call-sites (1 unsupported API, 1 skipped due to diagnostics) using 2 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/GlobalFetchSize.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/GlobalFetchSize.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/GlobalFetchSize.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/GlobalFetchSize.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/IncludeSqlSource.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/IncludeSqlSource.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/IncludeSqlSource.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/IncludeSqlSource.output.txt
@@ -5,7 +5,7 @@ Warning CS0618 Interceptors/IncludeSqlSource.input.cs L8 C28
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers
 Output code has 1 diagnostics from 'Interceptors/IncludeSqlSource.input.cs':
 
 Warning CS0618 Interceptors/IncludeSqlSource.input.cs L8 C28

--- a/test/Dapper.AOT.Test/Interceptors/InheritedMembers.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/InheritedMembers.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/InheritedMembers.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/InheritedMembers.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/MappedSqlDetection.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/MappedSqlDetection.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 7 of 7 possible call-sites using 4 interceptors, 4 commands and 0 readers
+Dapper.AOT handled 7 of 7 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 4 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/MappedSqlDetection.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/MappedSqlDetection.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 7 of 7 possible call-sites using 4 interceptors, 4 commands and 0 readers
+Dapper.AOT handled 7 of 7 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 4 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/MiscDiagnostics.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/MiscDiagnostics.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 9 of 9 possible call-sites using 8 interceptors, 3 commands and 3 readers
+Dapper.AOT handled 9 of 23 enabled call-sites (0 unsupported API, 14 skipped due to diagnostics) using 8 interceptors, 3 commands and 3 readers

--- a/test/Dapper.AOT.Test/Interceptors/MiscDiagnostics.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/MiscDiagnostics.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 9 of 9 possible call-sites using 8 interceptors, 3 commands and 3 readers
+Dapper.AOT handled 9 of 23 enabled call-sites (0 unsupported API, 14 skipped due to diagnostics) using 8 interceptors, 3 commands and 3 readers

--- a/test/Dapper.AOT.Test/Interceptors/NonConstant.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/NonConstant.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/NonConstant.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/NonConstant.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 1 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/NonFactoryMethod.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/NonFactoryMethod.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/NonFactoryMethod.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/NonFactoryMethod.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 2 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/OmitAttribute.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/OmitAttribute.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/OmitAttribute.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/OmitAttribute.output.txt
@@ -5,7 +5,7 @@ Warning CS0618 Interceptors/OmitAttribute.input.cs L7 C28
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 0 readers
 Output code has 1 diagnostics from 'Interceptors/OmitAttribute.input.cs':
 
 Warning CS0618 Interceptors/OmitAttribute.input.cs L7 C28

--- a/test/Dapper.AOT.Test/Interceptors/Query.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Query.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 7 of 7 possible call-sites using 7 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 7 of 7 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 7 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/Query.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Query.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 9 of 9 possible call-sites using 9 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 9 of 9 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 9 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithConstructor.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithConstructor.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 12 of 12 possible call-sites using 12 interceptors, 0 commands and 12 readers
+Dapper.AOT handled 12 of 12 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 12 interceptors, 0 commands and 12 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithConstructor.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithConstructor.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 12 of 12 possible call-sites using 12 interceptors, 0 commands and 12 readers
+Dapper.AOT handled 12 of 12 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 12 interceptors, 0 commands and 12 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithFactoryMethod.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithFactoryMethod.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 4 of 4 possible call-sites using 4 interceptors, 0 commands and 4 readers
+Dapper.AOT handled 4 of 4 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 0 commands and 4 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithFactoryMethod.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryCustomConstructionWithFactoryMethod.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 4 of 4 possible call-sites using 4 interceptors, 0 commands and 4 readers
+Dapper.AOT handled 4 of 4 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 0 commands and 4 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryDetection.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryDetection.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 11 of 11 possible call-sites using 7 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 11 of 11 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 7 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryDetection.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryDetection.output.txt
@@ -5,7 +5,7 @@ Warning CS0618 Interceptors/QueryDetection.input.cs L7 C28
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 11 of 11 possible call-sites using 7 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 11 of 11 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 7 interceptors, 1 commands and 1 readers
 Output code has 1 diagnostics from 'Interceptors/QueryDetection.input.cs':
 
 Warning CS0618 Interceptors/QueryDetection.input.cs L7 C28

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 2 of 6 enabled call-sites (0 unsupported API, 4 skipped due to diagnostics) using 2 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryEnumerableParams.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 2 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 2 of 6 enabled call-sites (0 unsupported API, 4 skipped due to diagnostics) using 2 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryMultiType.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryMultiType.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 0 of 12 enabled call-sites (12 unsupported API, 0 skipped due to diagnostics) using 0 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryMultiType.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryMultiType.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 0 of 12 enabled call-sites (12 unsupported API, 0 skipped due to diagnostics) using 0 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryMultiple.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryMultiple.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 0 of 2 enabled call-sites (2 unsupported API, 0 skipped due to diagnostics) using 0 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryMultiple.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryMultiple.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 0 of 2 enabled call-sites (2 unsupported API, 0 skipped due to diagnostics) using 0 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryNonGeneric.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryNonGeneric.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 15 of 15 possible call-sites using 15 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 15 of 15 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 15 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryNonGeneric.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryNonGeneric.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 17 of 17 possible call-sites using 17 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 17 of 17 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 17 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryPrimitive.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryPrimitive.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 18 of 18 possible call-sites using 18 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 18 of 18 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 18 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryPrimitive.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryPrimitive.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 21 of 21 possible call-sites using 21 interceptors, 0 commands and 0 readers
+Dapper.AOT handled 21 of 21 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 21 interceptors, 0 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 8 of 8 possible call-sites using 4 interceptors, 0 commands and 4 readers
+Dapper.AOT handled 8 of 8 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 0 commands and 4 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryStrictBind.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 8 of 8 possible call-sites using 4 interceptors, 0 commands and 4 readers
+Dapper.AOT handled 8 of 8 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 4 interceptors, 0 commands and 4 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryUntyped.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryUntyped.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 21 of 21 possible call-sites using 21 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 21 of 21 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 21 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/QueryUntyped.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/QueryUntyped.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 25 of 25 possible call-sites using 25 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 25 of 25 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 25 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/RequiredProperties.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/RequiredProperties.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/RequiredProperties.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/RequiredProperties.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 1 commands and 1 readers
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 1 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/RowCountHint.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/RowCountHint.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 3 of 3 possible call-sites using 3 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 3 of 3 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 3 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/RowCountHint.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/RowCountHint.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 3 of 3 possible call-sites using 3 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 3 of 3 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 3 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/Single.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Single.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 8 of 8 possible call-sites using 8 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 8 of 8 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 8 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/Single.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Single.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 8 of 8 possible call-sites using 8 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 8 of 8 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 8 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/SqlDetection.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/SqlDetection.output.netfx.txt
@@ -1,7 +1,7 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 7 of 7 possible call-sites using 5 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 7 of 7 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 5 interceptors, 2 commands and 0 readers
 Output code has 2 diagnostics from 'Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs':
 
 Warning CS8604 Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs L59 C194

--- a/test/Dapper.AOT.Test/Interceptors/SqlDetection.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/SqlDetection.output.txt
@@ -1,7 +1,7 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 7 of 7 possible call-sites using 5 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 7 of 7 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 5 interceptors, 2 commands and 0 readers
 Output code has 1 diagnostics from 'Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs':
 
 Warning CS8620 Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs L72 C194

--- a/test/Dapper.AOT.Test/Interceptors/SqlParse.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/SqlParse.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 10 of 10 possible call-sites using 3 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 10 of 12 enabled call-sites (0 unsupported API, 2 skipped due to diagnostics) using 3 interceptors, 2 commands and 0 readers

--- a/test/Dapper.AOT.Test/Interceptors/SqlParse.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/SqlParse.output.txt
@@ -5,7 +5,7 @@ Warning CS0618 Interceptors/SqlParse.input.cs L50 C28
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 10 of 10 possible call-sites using 3 interceptors, 2 commands and 0 readers
+Dapper.AOT handled 10 of 12 enabled call-sites (0 unsupported API, 2 skipped due to diagnostics) using 3 interceptors, 2 commands and 0 readers
 Output code has 1 diagnostics from 'Interceptors/SqlParse.input.cs':
 
 Warning CS0618 Interceptors/SqlParse.input.cs L50 C28

--- a/test/Dapper.AOT.Test/Interceptors/Techempower.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Techempower.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 5 of 5 possible call-sites using 3 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 5 of 6 enabled call-sites (0 unsupported API, 1 skipped due to diagnostics) using 3 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/Techempower.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/Techempower.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 5 of 5 possible call-sites using 3 interceptors, 2 commands and 1 readers
+Dapper.AOT handled 5 of 6 enabled call-sites (0 unsupported API, 1 skipped due to diagnostics) using 3 interceptors, 2 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/TopLevelStatements.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/TopLevelStatements.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 1 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/TopLevelStatements.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/TopLevelStatements.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 2 of 2 possible call-sites using 1 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 2 of 2 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/TsqlTips.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/TsqlTips.output.netfx.txt
@@ -1,7 +1,7 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 54 of 54 possible call-sites using 10 interceptors, 3 commands and 1 readers
+Dapper.AOT handled 54 of 56 enabled call-sites (0 unsupported API, 2 skipped due to diagnostics) using 10 interceptors, 3 commands and 1 readers
 Output code has 1 diagnostics from 'Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs':
 
 Warning CS8604 Dapper.AOT.Analyzers/Dapper.CodeAnalysis.DapperInterceptorGenerator/Test.generated.cs L113 C198

--- a/test/Dapper.AOT.Test/Interceptors/TsqlTips.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/TsqlTips.output.txt
@@ -20,7 +20,7 @@ Warning CS0618 Interceptors/TsqlTips.input.cs L166 C27
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 54 of 54 possible call-sites using 10 interceptors, 3 commands and 1 readers
+Dapper.AOT handled 54 of 56 enabled call-sites (0 unsupported API, 2 skipped due to diagnostics) using 10 interceptors, 3 commands and 1 readers
 Output code has 6 diagnostics from 'Interceptors/TsqlTips.input.cs':
 
 Warning CS0618 Interceptors/TsqlTips.input.cs L6 C27

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.netfx.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 1 of 4 enabled call-sites (0 unsupported API, 3 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/UnconstructableResults.output.txt
@@ -1,4 +1,4 @@
 Generator produced 1 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 1 possible call-sites using 1 interceptors, 0 commands and 1 readers
+Dapper.AOT handled 1 of 4 enabled call-sites (0 unsupported API, 3 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Verifiers/DAP004.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP004.cs
@@ -20,7 +20,8 @@ public class DAP004 : Verifier<WrappedDapperInterceptorAnalyzer>
         }
         """,
         [InterceptorsEnabled, WithCSharpLanguageVersion(LanguageVersion.CSharp10)],
-        [Diagnostic(DapperInterceptorGenerator.Diagnostics.LanguageVersionTooLow)]);
+        [Diagnostic(DapperInterceptorGenerator.Diagnostics.LanguageVersionTooLow),
+         Diagnostic(DapperInterceptorGenerator.Diagnostics.InterceptorsGenerated).WithArguments(0, 1, 0, 0, 0, 0, 0)]);
 
     [Fact]
     public Task CSFineIfInactive() => CSVerifyAsync("""


### PR DESCRIPTION
"handled 396 of 396 possible call-sites" alongside 96 compile errors is how the Dapper-test-suite exercise started: unsupported APIs (`QueryMultiple`, multi-map, …) and diagnostic-refused call-sites simply vanished from the DAP000 denominator, because `Parse` returned null for them.

They now flow through as a lightweight `SkippedSourceState`, and the message reads:

> handled {X} of {Y} enabled call-sites ({A} unsupported API, {B} skipped due to diagnostics) using {N} interceptors, …

so `Y = X + A + B` and 100% means what it says. Two previously-silent cases also report now: prerequisite failures (e.g. C# version too low → "handled 0 of N"), and compilations whose only Dapper usage is unsupported (previously: no DAP000 at all).

Every golden `.txt` regenerates with the new wording (that's most of the diff); the DAP000 rule doc now defines the three buckets, including the caveat that "handled" is a build-time statement — behavioral parity is what tests are for. Full unit suite green on net10.0 and net48.

On the Dapper test suite this changes the headline from `387 of 387` to the true ratio — I'll post the measured numbers once this lands.