### PR TITLE
Generator capture model: the full projection (phase 2 of 2)

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Multi.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Multi.cs
@@ -11,7 +11,7 @@ public sealed partial class DapperInterceptorGenerator
         CodeWriter sb,
         OperationFlags flags,
         OperationFlags commandTypeMode,
-        ITypeSymbol? parameterType,
+        ParamPlan? parameterType,
         string map, bool cache,
         EquatableArray<MethodParam> methodParameters,
         CommandFactoryState factories,
@@ -24,16 +24,16 @@ public sealed partial class DapperInterceptorGenerator
             return false;
         }
 
-        if (Inspection.IsCollectionType(parameterType, out var elementType, out var castType))
+        if (parameterType is { IsCollection: true, Element: { } elementPlan, CastType: { } castType })
         {
-            WriteMultiExecExpression(elementType!, castType);
+            WriteMultiExecExpression(elementPlan, castType);
             return true;
         }
 
         // no multi type found to cast to, so not using multiexec
         return false;
 
-        void WriteMultiExecExpression(ITypeSymbol elementType, string castType)
+        void WriteMultiExecExpression(ParamPlan elementType, string castType)
         {
             // return Command<type>
             sb.Append("return global::Dapper.DapperAotExtensions.Command");
@@ -56,7 +56,7 @@ public sealed partial class DapperInterceptorGenerator
             sb.Append(");").NewLine();
         }
 
-        void WriteBatchCommandArguments(ITypeSymbol elementType)
+        void WriteBatchCommandArguments(ParamPlan elementType)
         {
             // cnn, transaction, sql
             sb.Append("(cnn, ").Append(Forward(methodParameters, "transaction")).Append(", ");

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Single.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Single.cs
@@ -14,7 +14,7 @@ public sealed partial class DapperInterceptorGenerator
         RowPlan? resultPlan,
         OperationFlags flags,
         OperationFlags commandTypeMode,
-        ITypeSymbol? parameterType,
+        ParamPlan? parameterType,
         string map, bool cache,
         in EquatableArray<MethodParam> methodParameters,
         in CommandFactoryState factories,
@@ -120,9 +120,9 @@ public sealed partial class DapperInterceptorGenerator
             {
                 sb.Append(", rowCountHint: ").Append(additionalCommandState.RowCountHint);
             }
-            else if (parameterType is not null && !parameterType.IsAnonymousType)
+            else if (parameterType is not null && !parameterType.IsAnonymous)
             {
-                sb.Append(", rowCountHint: ((").Append(parameterType).Append(")param!).").Append(additionalCommandState.RowCountHintMemberName);
+                sb.Append(", rowCountHint: ((").Append(parameterType.TypeName).Append(")param!).").Append(additionalCommandState.RowCountHintMemberName);
             }
         }
         if (isAsync && HasParam(methodParameters, "cancellationToken"))
@@ -146,15 +146,15 @@ public sealed partial class DapperInterceptorGenerator
         }
         sb.Append(";").NewLine();
 
-        static CodeWriter WriteTypedArg(CodeWriter sb, ITypeSymbol? parameterType)
+        static CodeWriter WriteTypedArg(CodeWriter sb, ParamPlan? parameterType)
         {
-            if (parameterType is null || parameterType.IsAnonymousType)
+            if (parameterType is null || parameterType.IsAnonymous)
             {
                 sb.Append("param");
             }
             else
             {
-                sb.Append("(").Append(parameterType).Append(")param!");
+                sb.Append("(").Append(parameterType.TypeName).Append(")param!");
             }
             return sb;
         }

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Single.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.Single.cs
@@ -11,7 +11,7 @@ public sealed partial class DapperInterceptorGenerator
     static void WriteSingleImplementation(
         CodeWriter sb,
         InterceptedMethod method,
-        ITypeSymbol? resultType,
+        RowPlan? resultPlan,
         OperationFlags flags,
         OperationFlags commandTypeMode,
         ITypeSymbol? parameterType,
@@ -93,7 +93,7 @@ public sealed partial class DapperInterceptorGenerator
                         break;
                 }
             }
-            sb.AppendReader(resultType, readers, flags, additionalCommandState?.QueryColumns ?? default);
+            sb.AppendReader(resultPlan, readers, flags);
         }
         else if (flags.HasAny(OperationFlags.Execute))
         {
@@ -105,7 +105,7 @@ public sealed partial class DapperInterceptorGenerator
             sb.Append(isAsync ? "Async" : "");
             if (method.Arity == 1)
             {
-                sb.Append("<").Append(resultType).Append(">");
+                sb.Append("<").Append(resultPlan?.TypeName).Append(">");
             }
             sb.Append("(");
             WriteTypedArg(sb, parameterType);

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -56,10 +56,13 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
     
     public override void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        // note the cached values are all plain data (see ModelShapeTests): symbols are fully
+        // projected during parse, and the raw Compilation must not feed the output step
         var nodes = context.SyntaxProvider.CreateSyntaxProvider(PreFilter, Parse)
                     .Where(x => x is not null)
                     .Select((x, _) => x!);
-        var combined = context.CompilationProvider.Combine(nodes.Collect());
+        var env = context.CompilationProvider.Select(static (c, _) => CreateEnvironment(c));
+        var combined = env.Combine(nodes.Collect());
         context.RegisterImplementationSourceOutput(combined, Generate);
     }
 
@@ -207,6 +210,37 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
     }
 
 
+    internal static InterceptorEnvironment CreateEnvironment(Compilation compilation)
+    {
+        var dbCommandTypes = IdentifyDbCommandTypes(compilation, out var needsCommandPrep);
+        EquatableArray<SpecialDbCommandType> special = default;
+        if (!dbCommandTypes.IsDefaultOrEmpty)
+        {
+            var builder = new List<SpecialDbCommandType>();
+            foreach (var type in dbCommandTypes)
+            {
+                var flags = GetSpecialCommandFlags(type);
+                if (flags != SpecialCommandFlags.None)
+                {
+                    builder.Add(new SpecialDbCommandType(CodeWriter.GetAppendTypeName(type), type.Name,
+                        (flags & SpecialCommandFlags.BindByName) != 0,
+                        (flags & SpecialCommandFlags.InitialLONGFetchSize) != 0));
+                }
+            }
+            if (builder.Count != 0) special = new(builder.ToArray());
+        }
+        var baseFactory = GetCommandFactory(compilation, out var canConstruct);
+        return new InterceptorEnvironment(
+            allowUnsafe: compilation.Options is CSharpCompilationOptions cSharp && cSharp.AllowUnsafe,
+            assemblyName: compilation.AssemblyName,
+            hasInterceptsLocationAttribute: PreGeneratedCodeWriter.HasInterceptsLocationAttribute(compilation),
+            needsCommandPrep: needsCommandPrep,
+            baseCommandFactoryName: baseFactory,
+            baseFactoryCanConstruct: canConstruct,
+            specialCommandTypes: special,
+            systemObjectPlan: ParamPlan.Create(compilation.GetSpecialType(SpecialType.System_Object))!);
+    }
+
     private static string? GetCommandFactory(Compilation compilation, out bool canConstruct)
     {
         foreach (var attribute in compilation.SourceModule.GetAttributes())
@@ -275,7 +309,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         
     }
 
-    private void Generate(SourceProductionContext ctx, (Compilation Compilation, ImmutableArray<SourceState> Nodes) state)
+    private void Generate(SourceProductionContext ctx, (InterceptorEnvironment Environment, ImmutableArray<SourceState> Nodes) state)
     {
         try
         {
@@ -317,9 +351,10 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             return;
         }
 
-        var dbCommandTypes = IdentifyDbCommandTypes(ctx.Compilation, out var needsCommandPrep);
+        var env = ctx.Environment;
+        bool needsCommandPrep = env.NeedsCommandPrep;
 
-        bool allowUnsafe = ctx.Compilation.Options is CSharpCompilationOptions cSharp && cSharp.AllowUnsafe;
+        bool allowUnsafe = env.AllowUnsafe;
         var sb = new CodeWriter().Append("#nullable enable").NewLine()
             .Append("#pragma warning disable IDE0078 // unnecessary suppression is necessary").NewLine()
             .Append("#pragma warning disable CS9270 // SDK-dependent change to interceptors usage").NewLine()
@@ -327,7 +362,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             .Append("file static class DapperGeneratedInterceptors").Indent().NewLine();
         int methodIndex = 0, callSiteCount = 0;
 
-        var factories = new CommandFactoryState(ctx.Compilation);
+        var factories = new CommandFactoryState(env.SystemObjectPlan);
         var readers = new RowReaderState();
 
         foreach (var grp in ctx.Nodes.OfType<SuccessSourceState>().Where(x => !x.Flags.HasAny(OperationFlags.DoNotGenerate)).GroupBy(x => x.Group(), CommonComparer.Instance))
@@ -451,7 +486,8 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             sb.Outdent().NewLine().NewLine();
         }
 
-        var baseCommandFactory = GetCommandFactory(ctx.Compilation, out var canConstruct) ?? DapperBaseCommandFactory;
+        var baseCommandFactory = env.BaseCommandFactoryName ?? DapperBaseCommandFactory;
+        var canConstruct = env.BaseFactoryCanConstruct;
         if (needsCommandPrep || !canConstruct)
         {
             // at least one command-type needs special handling; do that
@@ -461,24 +497,20 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                 sb.Append("public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)").Indent().NewLine()
                 .Append("var cmd = base.GetCommand(connection, sql, commandType, args);");
                 int cmdTypeIndex = 0;
-                foreach (var type in dbCommandTypes)
+                foreach (var special in env.SpecialCommandTypes)
                 {
-                    var flags = GetSpecialCommandFlags(type);
-                    if (flags != SpecialCommandFlags.None)
+                    sb.NewLine().Append("// apply special per-provider command initialization logic for ").Append(special.ShortName).NewLine()
+                        .Append(cmdTypeIndex == 0 ? "" : "else ").Append("if (cmd is ").Append(special.TypeName).Append(" cmd").Append(cmdTypeIndex).Append(")").Indent().NewLine();
+                    if (special.BindByName)
                     {
-                        sb.NewLine().Append("// apply special per-provider command initialization logic for ").Append(type.Name).NewLine()
-                            .Append(cmdTypeIndex == 0 ? "" : "else ").Append("if (cmd is ").Append(type).Append(" cmd").Append(cmdTypeIndex).Append(")").Indent().NewLine();
-                        if ((flags & SpecialCommandFlags.BindByName) != 0)
-                        {
-                            sb.Append("cmd").Append(cmdTypeIndex).Append(".BindByName = true;").NewLine();
-                        }
-                        if ((flags & SpecialCommandFlags.InitialLONGFetchSize) != 0)
-                        {
-                            sb.Append("cmd").Append(cmdTypeIndex).Append(".InitialLONGFetchSize = -1;").NewLine();
-                        }
-                        sb.Outdent().NewLine();
-                        cmdTypeIndex++;
+                        sb.Append("cmd").Append(cmdTypeIndex).Append(".BindByName = true;").NewLine();
                     }
+                    if (special.InitialLONGFetchSize)
+                    {
+                        sb.Append("cmd").Append(cmdTypeIndex).Append(".InitialLONGFetchSize = -1;").NewLine();
+                    }
+                    sb.Outdent().NewLine();
+                    cmdTypeIndex++;
                 }
                 sb.Append("return cmd;").Outdent().NewLine();
             }
@@ -511,10 +543,10 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         sb.Outdent().Outdent(); // ends our generated file-scoped class and the namespace
         
-        var preGeneratedCodeWriter = new PreGeneratedCodeWriter(sb, ctx.Compilation);
+        var preGeneratedCodeWriter = new PreGeneratedCodeWriter(sb, env.HasInterceptsLocationAttribute);
         preGeneratedCodeWriter.Write(ctx.GeneratorContext.IncludedGenerationTypes);
 
-        ctx.AddSource((ctx.Compilation.AssemblyName ?? "package") + ".generated.cs", sb.ToString());
+        ctx.AddSource((env.AssemblyName ?? "package") + ".generated.cs", sb.ToString());
         ctx.ReportDiagnostic(Diagnostic.Create(Diagnostics.InterceptorsGenerated, null,
             callSiteCount, callSiteCount + unsupported + skippedViaDiagnostics, unsupported, skippedViaDiagnostics,
             methodIndex, factories.Count(), readers.Count()));

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -168,7 +168,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             return new SuccessSourceState(new LocationSnapshot(location), InterceptorFilePath(ctx, location), languageVersion,
                 ProjectMethod(op.TargetMethod), flags, sql,
                 RowPlan.Create(resultType, additionalState?.QueryColumns ?? default),
-                argExpression?.Type, parameterMap, additionalState);
+                ParamPlan.Create(argExpression?.Type), parameterMap, additionalState);
         }
         catch (Exception ex)
         {
@@ -333,7 +333,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         foreach (var grp in ctx.Nodes.OfType<SuccessSourceState>().Where(x => !x.Flags.HasAny(OperationFlags.DoNotGenerate)).GroupBy(x => x.Group(), CommonComparer.Instance))
         {
             // first, try to resolve the helper method that we're going to use for this
-            var (flags, method, parameterType, parameterMap, _, additionalCommandState) = grp.Key;
+            var (flags, method, parameterPlan, parameterMap, _, additionalCommandState) = grp.Key;
             const bool useUnsafe = false;
             int usageCount = 0;
 
@@ -368,7 +368,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             sb.Append("// ").Append(flags.ToString()).NewLine();
             if (flags.HasAny(OperationFlags.HasParameters))
             {
-                sb.Append("// takes parameter: ").Append(parameterType).NewLine();
+                sb.Append("// takes parameter: ").Append(parameterPlan!.TypeName).NewLine();
             }
             if (!string.IsNullOrWhiteSpace(grp.Key.ParameterMap))
             {
@@ -443,9 +443,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             {
                 WriteGetRowParser(sb, resultPlan, readers, grp.Key.Flags);
             }
-            else if (!TryWriteMultiExecImplementation(sb, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, fixedSql, additionalCommandState))
+            else if (!TryWriteMultiExecImplementation(sb, flags, commandTypeMode, parameterPlan, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, fixedSql, additionalCommandState))
             {
-                WriteSingleImplementation(sb, method, resultPlan, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, readers, fixedSql, additionalCommandState);
+                WriteSingleImplementation(sb, method, resultPlan, flags, commandTypeMode, parameterPlan, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, readers, fixedSql, additionalCommandState);
             }
 
             sb.Outdent().NewLine().NewLine();
@@ -506,7 +506,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         foreach (var tuple in factories)
         {
-            WriteCommandFactory(ctx, baseCommandFactory, sb, tuple.Type, tuple.Index, tuple.Map, tuple.CacheCount, tuple.AdditionalCommandState);
+            WriteCommandFactory(ctx, baseCommandFactory, sb, tuple.Plan, tuple.Index, tuple.Map, tuple.CacheCount, tuple.AdditionalCommandState);
         }
 
         sb.Outdent().Outdent(); // ends our generated file-scoped class and the namespace
@@ -526,14 +526,14 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             .Append(".GetRowParser(reader, startIndex, length, returnNullIfFirstMissing);").NewLine();
     }
 
-    private static void WriteCommandFactory(in GenerateState ctx, string baseFactory, CodeWriter sb, ITypeSymbol type, int index, string map, int cacheCount, AdditionalCommandState? additionalCommandState)
+    private static void WriteCommandFactory(in GenerateState ctx, string baseFactory, CodeWriter sb, ParamPlan type, int index, string map, int cacheCount, AdditionalCommandState? additionalCommandState)
     {
-        var declaredType = type.IsAnonymousType ? "object?" : CodeWriter.GetTypeName(type);
+        var declaredType = type.DeclaredType;
         sb.Append("private ").Append(cacheCount <= 1 ? "sealed" : "abstract").Append(" class CommandFactory").Append(index).Append(" : ")
             .Append(baseFactory).Append("<").Append(declaredType).Append(">");
-        if (type.IsAnonymousType)
+        if (type.IsAnonymous)
         {
-            sb.Append(" // ").Append(type); // give the reader a clue
+            sb.Append(" // ").Append(type.TypeName); // give the reader a clue
         }
         sb.Indent().NewLine();
 
@@ -559,7 +559,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                 break;
         }
 
-        if (Inspection.IsCancellationToken(type))
+        if (type.IsCancellationTokenType)
         {
             sb.Append("public override global::System.Threading.CancellationToken GetCancellationToken(").Append(declaredType).Append(" args) => args;").NewLine();
         }
@@ -1092,7 +1092,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         GetCancellationToken
     }
 
-    private static void WriteArgs(in GenerateState ctx, ITypeSymbol? parameterType, CodeWriter sb, WriteArgsMode mode, string map, ref WriteArgsFlags flags)
+    private static void WriteArgs(in GenerateState ctx, ParamPlan? parameterType, CodeWriter sb, WriteArgsMode mode, string map, ref WriteArgsFlags flags)
     {
         if (parameterType is null)
         {
@@ -1101,11 +1101,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         var source = "args";
 
-        if (parameterType.IsAnonymousType)
+        if (parameterType.IsAnonymous)
         {
-            sb.Append("var typed = Cast(args, ");
-            AppendShapeLambda(sb, parameterType);
-            sb.Append("); // expected shape").NewLine();
+            sb.Append("var typed = Cast(args, ").Append(parameterType.ShapeLambda).Append("); // expected shape").NewLine();
             source = "typed";
         }
 
@@ -1116,10 +1114,10 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         bool first = true, firstTest = true;
         int parameterIndex = 0;
-        var memberMap = MemberMap.CreateForParameters(parameterType);
-        if (memberMap is null or { Members.IsDefaultOrEmpty: true }) return;
+        var planMembers = parameterType.Members;
+        if (planMembers.IsEmpty) return;
 
-        foreach (var member in memberMap.Members)
+        foreach (var member in planMembers)
         {
             if (!member.IsMapped) continue;
 
@@ -1204,7 +1202,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     sb.Append("p = cmd.CreateParameter();").NewLine();
                     sb.Append("p.ParameterName = ").AppendVerbatimLiteral(member.DbName).Append(";").NewLine();
 
-                    if (member.DapperSpecialType is DapperSpecialType.DbString)
+                    if (member.IsDbString)
                     {
                         ctx.GeneratorContext.IncludeGenerationType(IncludedGeneration.DbStringHelpers);
 
@@ -1215,30 +1213,10 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         break;
                     }
 
-                    var dbType = member.GetDbType(out _);
-                    var size = member.TryGetValue<int>("Size");
-                    bool useSetValueWithDefaultSize = false;
-                    if (dbType is not null)
+                    bool useSetValueWithDefaultSize = member.UseSetValueWithDefaultSize;
+                    if (member.HasDbType)
                     {
-                        sb.Append("p.DbType = global::System.Data.DbType.").Append(dbType.GetValueOrDefault().ToString()).Append(";").NewLine();
-                        if (size is null)
-                        {
-                            switch (dbType.GetValueOrDefault())
-                            {
-                                case DbType.Binary:
-                                case DbType.String:
-                                case DbType.AnsiString:
-                                    if (member.CodeType.SpecialType == SpecialType.System_String)
-                                    {
-                                        useSetValueWithDefaultSize = true;
-                                    }
-                                    else
-                                    {
-                                        size = -1; // default to [n]varchar(max)/varbinary(max)
-                                    }
-                                    break;
-                            }
-                        }
+                        sb.Append("p.DbType = global::System.Data.DbType.").Append(member.DbTypeName).Append(";").NewLine();
                     }
                     else
                     {
@@ -1246,9 +1224,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         // string/binary args to have a size, but: we've set that)
                         flags &= ~WriteArgsFlags.CanPrepare;
                     }
-                    AppendDbParameterSetting(sb, "Size", size);
-                    AppendDbParameterSetting(sb, "Precision", member.TryGetValue<byte>("Precision"));
-                    AppendDbParameterSetting(sb, "Scale", member.TryGetValue<byte>("Scale"));
+                    AppendDbParameterSetting(sb, "Size", member.EffectiveSize);
+                    AppendDbParameterSetting(sb, "Precision", member.Precision);
+                    AppendDbParameterSetting(sb, "Scale", member.Scale);
 
                     sb.Append("p.Direction = global::System.Data.ParameterDirection.").Append(direction switch
                     {
@@ -1288,7 +1266,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     }
                     break;
                 case WriteArgsMode.Update:
-                    if (member.DapperSpecialType is DapperSpecialType.DbString)
+                    if (member.IsDbString)
                     {
                         ctx.GeneratorContext.IncludeGenerationType(IncludedGeneration.DbStringHelpers);
 
@@ -1319,7 +1297,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                 case WriteArgsMode.PostProcess:
                     // we already eliminated args that we don't need to look at
                     sb.Append(source).Append(".").Append(member.CodeName).Append(" = Parse<")
-                        .Append(member.CodeType).Append(">(ps[");
+                        .Append(member.TypeName).Append(">(ps[");
                     if ((flags & WriteArgsFlags.NeedsTest) != 0) sb.AppendVerbatimLiteral(member.DbName);
                     else sb.Append(parameterIndex);
                     sb.Append("].Value);").NewLine();
@@ -1346,35 +1324,6 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         if (value is not null)
         {
             sb.Append("p.").Append(memberName).Append(" = ").Append(value.GetValueOrDefault()).Append(";").NewLine();
-        }
-    }
-
-    private static void AppendShapeLambda(CodeWriter sb, ITypeSymbol parameterType)
-    {
-        var members = parameterType.GetMembers();
-        int count = CodeWriter.CountGettableInstanceMembers(members);
-        switch (count)
-        {
-            case 0:
-                sb.Append("static () => (object?)null");
-                break;
-            default:
-                bool first = true;
-                sb.Append("static () => new {");
-                foreach (var member in members)
-                {
-                    if (CodeWriter.IsGettableInstanceMember(member, out var type))
-                    {
-                        sb.Append(first ? " " : ", ").Append(member.Name).Append(" = default(").Append(type).Append(")");
-                        if (type.IsReferenceType && type.NullableAnnotation == NullableAnnotation.None)
-                        {
-                            sb.Append("!");
-                        }
-                        first = false;
-                    }
-                }
-                sb.Append(" }");
-                break;
         }
     }
 
@@ -1489,6 +1438,8 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
     internal abstract class SourceState
     {
+        // note: the incremental driver caches these values per node and decides re-runs by
+        // equality, so every subclass must provide *structural* equality (see ModelShapeTests)
         public LocationSnapshot Location { get; }
         protected SourceState(in LocationSnapshot location) => Location = location;
     }
@@ -1501,6 +1452,11 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         public OperationFlags Flags { get; }
         public SkippedSourceState(in LocationSnapshot location, OperationFlags flags) : base(location)
             => Flags = flags;
+
+        public bool Equals(SkippedSourceState? other) => other is not null
+            && Location.Equals(other.Location) && Flags == other.Flags;
+        public override bool Equals(object? obj) => Equals(obj as SkippedSourceState);
+        public override int GetHashCode() => Location.GetHashCode() ^ (int)Flags;
     }
 
     internal sealed class FaultSourceState : SourceState
@@ -1509,6 +1465,13 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         public FaultSourceState(in LocationSnapshot location, Exception fault) : base(location)
             => Fault = fault;
+
+        public bool Equals(FaultSourceState? other) => other is not null
+            && Location.Equals(other.Location)
+            && Fault.GetType() == other.Fault.GetType()
+            && string.Equals(Fault.Message, other.Fault.Message, StringComparison.Ordinal);
+        public override bool Equals(object? obj) => Equals(obj as FaultSourceState);
+        public override int GetHashCode() => Location.GetHashCode();
     }
 
     internal sealed class SuccessSourceState : SourceState
@@ -1521,12 +1484,12 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         public string ParameterMap { get; }
         public InterceptedMethod Method { get; }
         public RowPlan? ResultPlan { get; }
-        public ITypeSymbol? ParameterType { get; }
+        public ParamPlan? ParameterPlan { get; }
         public AdditionalCommandState? AdditionalCommandState { get; }
 
         public SuccessSourceState(in LocationSnapshot location, string interceptorFilePath, int languageVersion,
             InterceptedMethod method, OperationFlags flags, string? sql,
-            RowPlan? resultPlan, ITypeSymbol? parameterType, string parameterMap,
+            RowPlan? resultPlan, ParamPlan? parameterPlan, string parameterMap,
             AdditionalCommandState? additionalCommandState) : base(location)
         {
             InterceptorFilePath = interceptorFilePath;
@@ -1534,18 +1497,38 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             Flags = flags;
             Sql = sql;
             ResultPlan = resultPlan;
-            ParameterType = parameterType;
+            ParameterPlan = parameterPlan;
             Method = method;
             ParameterMap = parameterMap;
             AdditionalCommandState = additionalCommandState;
         }
 
-        public (OperationFlags Flags, InterceptedMethod Method, ITypeSymbol? ParameterType, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) Group()
-            => new(Flags, Method, ParameterType, ParameterMap, (Flags & (OperationFlags.CacheCommand | OperationFlags.IncludeLocation)) == 0 ? null : Location, AdditionalCommandState);
+        public (OperationFlags Flags, InterceptedMethod Method, ParamPlan? ParameterPlan, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) Group()
+            => new(Flags, Method, ParameterPlan, ParameterMap, (Flags & (OperationFlags.CacheCommand | OperationFlags.IncludeLocation)) == 0 ? null : Location, AdditionalCommandState);
+
+        public bool Equals(SuccessSourceState? other) => other is not null
+            && Location.Equals(other.Location)
+            && string.Equals(InterceptorFilePath, other.InterceptorFilePath, StringComparison.Ordinal)
+            && LanguageVersion == other.LanguageVersion
+            && Flags == other.Flags
+            && string.Equals(Sql, other.Sql, StringComparison.Ordinal)
+            && string.Equals(ParameterMap, other.ParameterMap, StringComparison.Ordinal)
+            && Method.Equals(other.Method)
+            && Equals(ResultPlan, other.ResultPlan)
+            && Equals(ParameterPlan, other.ParameterPlan)
+            && Equals(AdditionalCommandState, other.AdditionalCommandState);
+        public override bool Equals(object? obj) => Equals(obj as SuccessSourceState);
+        public override int GetHashCode()
+        {
+            var hash = Location.GetHashCode();
+            hash = (hash * -47) + (int)Flags;
+            hash = (hash * -47) + Method.GetHashCode();
+            return hash;
+        }
     }
     private sealed class CommonComparer :
         IComparer<LocationSnapshot>,
-        IEqualityComparer<(OperationFlags Flags, InterceptedMethod Method, ITypeSymbol? ParameterType, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState)>
+        IEqualityComparer<(OperationFlags Flags, InterceptedMethod Method, ParamPlan? ParameterPlan, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState)>
     {
         public static readonly CommonComparer Instance = new();
         private CommonComparer() { }
@@ -1567,15 +1550,15 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         public bool Equals(
 
-            (OperationFlags Flags, InterceptedMethod Method, ITypeSymbol? ParameterType, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) x,
-            (OperationFlags Flags, InterceptedMethod Method, ITypeSymbol? ParameterType, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) y) => x.Flags == y.Flags
+            (OperationFlags Flags, InterceptedMethod Method, ParamPlan? ParameterPlan, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) x,
+            (OperationFlags Flags, InterceptedMethod Method, ParamPlan? ParameterPlan, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) y) => x.Flags == y.Flags
                 && x.ParameterMap == y.ParameterMap
                 && x.Method.Equals(y.Method)
-                && SymbolEqualityComparer.Default.Equals(x.ParameterType, y.ParameterType)
+                && Equals(x.ParameterPlan, y.ParameterPlan)
                 && Nullable.Equals(x.UniqueLocation, y.UniqueLocation)
                 && Equals(x.AdditionalCommandState, y.AdditionalCommandState);
 
-        public int GetHashCode((OperationFlags Flags, InterceptedMethod Method, ITypeSymbol? ParameterType, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) obj)
+        public int GetHashCode((OperationFlags Flags, InterceptedMethod Method, ParamPlan? ParameterPlan, string ParameterMap, LocationSnapshot? UniqueLocation, AdditionalCommandState? AdditionalCommandState) obj)
         {
             var hash = (int)obj.Flags;
             hash *= -47;
@@ -1583,9 +1566,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             hash *= -47;
             hash += obj.Method.GetHashCode();
             hash *= -47;
-            if (obj.ParameterType is not null)
+            if (obj.ParameterPlan is not null)
             {
-                hash += SymbolEqualityComparer.Default.GetHashCode(obj.ParameterType);
+                hash += obj.ParameterPlan.GetHashCode();
             }
             hash *= -47;
             if (obj.UniqueLocation is not null)

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -166,7 +166,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             Debug.Assert(!flags.HasAny(OperationFlags.DoNotGenerate), "should have already exited");
             int languageVersion = ctx.Node.SyntaxTree.Options is CSharpParseOptions csOptions ? (int)csOptions.LanguageVersion : -1;
             return new SuccessSourceState(new LocationSnapshot(location), InterceptorFilePath(ctx, location), languageVersion,
-                ProjectMethod(op.TargetMethod), flags, sql, resultType, argExpression?.Type, parameterMap, additionalState);
+                ProjectMethod(op.TargetMethod), flags, sql,
+                RowPlan.Create(resultType, additionalState?.QueryColumns ?? default),
+                argExpression?.Type, parameterMap, additionalState);
         }
         catch (Exception ex)
         {
@@ -377,11 +379,11 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     _ => grp.Key.ParameterMap,
                 }).NewLine();
             }
-            ITypeSymbol? resultType = null;
+            RowPlan? resultPlan = null;
             if (flags.HasAny(OperationFlags.TypedResult))
             {
-                resultType = grp.First().ResultType!;
-                sb.Append("// returns data: ").Append(resultType).NewLine();
+                resultPlan = grp.First().ResultPlan!;
+                sb.Append("// returns data: ").Append(resultPlan.TypeName).NewLine();
             }
 
             // assertions
@@ -439,11 +441,11 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
             if (flags.HasAny(OperationFlags.GetRowParser))
             {
-                WriteGetRowParser(sb, resultType, readers, grp.Key.Flags, grp.Key.AdditionalCommandState?.QueryColumns ?? default);
+                WriteGetRowParser(sb, resultPlan, readers, grp.Key.Flags);
             }
             else if (!TryWriteMultiExecImplementation(sb, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, fixedSql, additionalCommandState))
             {
-                WriteSingleImplementation(sb, method, resultType, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, readers, fixedSql, additionalCommandState);
+                WriteSingleImplementation(sb, method, resultPlan, flags, commandTypeMode, parameterType, grp.Key.ParameterMap, grp.Key.UniqueLocation is not null, methodParameters, factories, readers, fixedSql, additionalCommandState);
             }
 
             sb.Outdent().NewLine().NewLine();
@@ -499,7 +501,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
         foreach (var tuple in readers)
         {
-            WriteRowFactory(ctx, sb, tuple.Type, tuple.Index, tuple.Flags, tuple.QueryColumns, null /* TODO */);
+            WriteRowFactory(sb, tuple.Plan, tuple.Index, tuple.Flags);
         }
 
         foreach (var tuple in factories)
@@ -518,9 +520,9 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             methodIndex, factories.Count(), readers.Count()));
     }
 
-    private static void WriteGetRowParser(CodeWriter sb, ITypeSymbol? resultType, in RowReaderState readers, OperationFlags flags, in EquatableArray<string> queryColumns)
+    private static void WriteGetRowParser(CodeWriter sb, RowPlan? resultPlan, in RowReaderState readers, OperationFlags flags)
     {
-        sb.Append("return ").AppendReader(resultType, readers, flags, queryColumns)
+        sb.Append("return ").AppendReader(resultPlan, readers, flags)
             .Append(".GetRowParser(reader, startIndex, length, returnNullIfFirstMissing);").NewLine();
     }
 
@@ -753,14 +755,12 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         }
     }
 
-    private static void WriteRowFactory(in GenerateState context, CodeWriter sb, ITypeSymbol type, int index, OperationFlags flags, EquatableArray<string> queryColumns, Location? location)
+    private static void WriteRowFactory(CodeWriter sb, RowPlan plan, int index, OperationFlags flags)
     {
-        var map = MemberMap.CreateForResults(type, location);
-        if (map is null) return;
+        var members = plan.Members;
+        var queryColumns = plan.QueryColumns;
 
-        var members = map.MapQueryColumns(queryColumns);
-
-        if (members.IsDefaultOrEmpty && map.Constructor is null && map.FactoryMethod is null)
+        if (members.IsEmpty && !plan.UseConstructor && !plan.UseFactoryMethod)
         {
             // error is emitted, but we still generate default RowFactory to not emit more errors for this type
             WriteRowFactoryHeader();
@@ -769,31 +769,19 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             return;
         }
 
-        var hasInitOnlyMembers = members.Any(member => member.IsInitOnly);
-        var hasRequiredMembers = members.Any(member => member.IsRequired);
-        var hasGetOnlyMembers = members.Any(member => member is { IsGettable: true, IsSettable: false, IsInitOnly: false });
-        var useConstructorDeferred = map.Constructor is not null;
-        var useFactoryMethodDeferred = map.FactoryMethod is not null;
-        
-        // Implementation detail: 
-        // constructor takes advantage over factory method.
-        var useDeferredConstruction = useConstructorDeferred || useFactoryMethodDeferred || hasInitOnlyMembers || hasGetOnlyMembers || hasRequiredMembers;
+        var useDeferredConstruction = plan.UseDeferredConstruction;
 
         WriteRowFactoryHeader();
 
         WriteTokenizeMethod();
-        WriteReadMethod(context);
+        WriteReadMethod();
 
         WriteRowFactoryFooter();
 
         void WriteRowFactoryHeader()
         {
-            sb.Append("private sealed class RowFactory").Append(index).Append(" : global::Dapper.RowFactory").Append("<").Append(type).Append(">")
+            sb.Append("private sealed class RowFactory").Append(index).Append(" : global::Dapper.RowFactory").Append("<").Append(plan.TypeName).Append(">")
             .Indent().NewLine();
-            if (location is not null)
-            {
-                sb.Append("// specific to ").Append(location.ToString());
-            }
             if (flags != 0)
             {
                 sb.Append("// flags: ").Append(flags.ToString()).NewLine();
@@ -854,8 +842,8 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         }
                         else
                         {
-                            sb.Append("token = type == typeof(").Append(Inspection.MakeNonNullable(member.CodeType)).Append(") ? ").Append(token)
-                            .Append(" : ").Append(token + map.Members.Length).Append(";")
+                            sb.Append("token = type == typeof(").Append(member.NonNullTypeName).Append(") ? ").Append(token)
+                            .Append(" : ").Append(token + plan.TotalMemberCount).Append(";")
                             .Append(token == 0 ? " // two tokens for right-typed and type-flexible" : "");
                         }
                         sb.NewLine().Append("break;").Outdent(false).NewLine();
@@ -885,8 +873,8 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         var member = members[i];
                         if (member.IsMapped)
                         {
-                            sb.Append(i).Append(" => type == typeof(").Append(Inspection.MakeNonNullable(member.CodeType)).Append(") ? ").Append(i)
-                                .Append(" : ").Append(i + map.Members.Length).Append(",").NewLine();
+                            sb.Append(i).Append(" => type == typeof(").Append(member.NonNullTypeName).Append(") ? ").Append(i)
+                                .Append(" : ").Append(i + plan.TotalMemberCount).Append(",").NewLine();
                         }
                     }
                     sb.Append("_ => -1,").Outdent().Append(";").Outdent().NewLine();
@@ -895,18 +883,18 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
 
             sb.Append("return null;").Outdent().NewLine();
         }
-        void WriteReadMethod(in GenerateState context)
+        void WriteReadMethod()
         {
             const string DeferredConstructionVariableName = "value";
 
-            sb.Append("public override ").Append(type).Append(" Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)").Indent().NewLine();
+            sb.Append("public override ").Append(plan.TypeName).Append(" Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)").Indent().NewLine();
 
             int token = 0;
             var deferredMethodArgumentsOrdered = new SortedList<int, string>();
 
             if (useDeferredConstruction)
             {
-                // don't create an instance now, but define the variables to create an instance later like 
+                // don't create an instance now, but define the variables to create an instance later like
                 // ```
                 // Type? member0 = default;
                 // Type? member1 = default;
@@ -918,19 +906,19 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     {
                         var variableName = DeferredConstructionVariableName + token;
 
-                        if (Inspection.CouldBeNullable(member.CodeType)) sb.Append(CodeWriter.GetTypeName(member.CodeType.WithNullableAnnotation(NullableAnnotation.Annotated)));
-                        else sb.Append(CodeWriter.GetTypeName(member.CodeType));
+                        if (member.CouldBeNullable) sb.Append(member.AnnotatedTypeName);
+                        else sb.Append(member.TypeName);
 
                         sb.Append(' ').Append(variableName).Append(" = default")
                             // if "default" will violate NRT: add a !
-                            .Append(member.CodeType.IsReferenceType && member.CodeType.NullableAnnotation == NullableAnnotation.NotAnnotated ? "!" : "")
+                            .Append(member.NeedsDefaultBang ? "!" : "")
                             .Append(";").NewLine();
 
-                        if (useConstructorDeferred && member.ConstructorParameterOrder is not null)
+                        if (plan.UseConstructor && member.ConstructorParameterOrder is not null)
                         {
                             deferredMethodArgumentsOrdered.Add(member.ConstructorParameterOrder.Value, variableName);
                         }
-                        else if (useFactoryMethodDeferred && member.FactoryMethodParameterOrder is not null)
+                        else if (plan.UseFactoryMethod && member.FactoryMethodParameterOrder is not null)
                         {
                             deferredMethodArgumentsOrdered.Add(member.FactoryMethodParameterOrder.Value, variableName);
                         }
@@ -941,8 +929,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             else
             {
                 // we are not using a constructor, so we need to create an instance now
-                sb.Append(type.NullableAnnotation == NullableAnnotation.Annotated
-                    ? type.WithNullableAnnotation(NullableAnnotation.None) : type).Append(" result = new();").NewLine();
+                sb.Append(plan.NonNullTypeName).Append(" result = new();").NewLine();
             }
 
             if (!queryColumns.IsDefault && flags.HasAny(OperationFlags.StrictTypes))
@@ -962,10 +949,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
             {
                 if (member.IsMapped)
                 {
-                    var memberType = member.CodeType;
-
-                    member.GetDbType(out var readerMethod);
-                    var nullCheck = Inspection.CouldBeNullable(memberType) ? $"reader.IsDBNull(columnOffset) ? ({CodeWriter.GetTypeName(memberType.WithNullableAnnotation(NullableAnnotation.Annotated))})null : " : "";
+                    var nullCheck = member.CouldBeNullable ? $"reader.IsDBNull(columnOffset) ? ({member.AnnotatedTypeName})null : " : "";
                     sb.Append("case ").Append(token).Append(":").NewLine().Indent(false);
 
                     // write `result.X = ` or `member0 = `
@@ -974,13 +958,13 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     sb.Append(" = ");
 
                     sb.Append(nullCheck);
-                    if (readerMethod is null)
+                    if (member.ReaderMethod is null)
                     {
-                        sb.Append("reader.GetFieldValue<").Append(memberType).Append(">(columnOffset);");
+                        sb.Append("reader.GetFieldValue<").Append(member.TypeName).Append(">(columnOffset);");
                     }
                     else
                     {
-                        sb.Append("reader.").Append(readerMethod).Append("(columnOffset);");
+                        sb.Append("reader.").Append(member.ReaderMethod).Append("(columnOffset);");
                     }
 
 
@@ -989,7 +973,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     // optionally emit type-forgiving version
                     if (!flags.HasAny(OperationFlags.StrictTypes))
                     {
-                        sb.Append("case ").Append(token + map.Members.Length).Append(":").NewLine().Indent(false);
+                        sb.Append("case ").Append(token + plan.TotalMemberCount).Append(":").NewLine().Indent(false);
 
                         // write `result.X = ` or `member0 = `
                         if (useDeferredConstruction) sb.Append(DeferredConstructionVariableName).Append(token);
@@ -998,7 +982,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         sb.Append(" = ")
                             .Append(nullCheck)
                             .Append("GetValue<")
-                            .Append(Inspection.MakeNonNullable(memberType)).Append(">(reader, columnOffset);").NewLine()
+                            .Append(member.NonNullTypeName).Append(">(reader, columnOffset);").NewLine()
                             .Append("break;").NewLine().Outdent(false);
                     }
                 }
@@ -1020,21 +1004,21 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                 // or in case of factory method:
                 // return Type.Create(member0, member1, member2, ...)
                 // ```
-                
-                if (useConstructorDeferred)
+
+                if (plan.UseConstructor)
                 {
                     // `return new Type(member0, member1, member2, ...);`
-                    sb.Append("return new ").Append(type).Append('('); 
+                    sb.Append("return new ").Append(plan.TypeName).Append('(');
                     WriteDeferredMethodArgs();
                     sb.Append(')');
                     WriteDeferredInitialization();
                     sb.Append(";").Outdent();
                 }
-                else if (useFactoryMethodDeferred)
+                else if (plan.UseFactoryMethod)
                 {
                     // `return Type.FactoryCreate(member0, member1, member2, ...);`
-                    sb.Append("return ").Append(type)
-                      .Append('.').Append(map.FactoryMethod!.Name).Append('(');
+                    sb.Append("return ").Append(plan.TypeName)
+                      .Append('.').Append(plan.FactoryMethodName).Append('(');
                     WriteDeferredMethodArgs();
                     sb.Append(')').Append(";").Outdent();
                 }
@@ -1046,16 +1030,16 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     //      Member1 = value1,
                     //      Member2 = value2
                     // }
-                    sb.Append("return new ").Append(type);
+                    sb.Append("return new ").Append(plan.TypeName);
                     WriteDeferredInitialization();
                     sb.Append(";").Outdent();
                 }
 
                 void WriteDeferredInitialization()
-                {   
+                {
                     // if all members are constructor arguments, no need to set them again
                     if (deferredMethodArgumentsOrdered!.Count == members.Length) return;
-                    
+
                     sb.Indent().NewLine();
                     token = -1;
                     foreach (var member in members)
@@ -1069,11 +1053,11 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                     }
                     sb.Outdent(withScope: false).Append("}");
                 }
-                
+
                 void WriteDeferredMethodArgs()
                 {
                     if (deferredMethodArgumentsOrdered!.Count == 0) return;
-                    
+
                     // write `member0, member1, member2, ...` part of method
                     foreach (var constructorArg in deferredMethodArgumentsOrdered!)
                     {
@@ -1536,20 +1520,20 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
         public string? Sql { get; }
         public string ParameterMap { get; }
         public InterceptedMethod Method { get; }
-        public ITypeSymbol? ResultType { get; }
+        public RowPlan? ResultPlan { get; }
         public ITypeSymbol? ParameterType { get; }
         public AdditionalCommandState? AdditionalCommandState { get; }
 
         public SuccessSourceState(in LocationSnapshot location, string interceptorFilePath, int languageVersion,
             InterceptedMethod method, OperationFlags flags, string? sql,
-            ITypeSymbol? resultType, ITypeSymbol? parameterType, string parameterMap,
+            RowPlan? resultPlan, ITypeSymbol? parameterType, string parameterMap,
             AdditionalCommandState? additionalCommandState) : base(location)
         {
             InterceptorFilePath = interceptorFilePath;
             LanguageVersion = languageVersion;
             Flags = flags;
             Sql = sql;
-            ResultType = resultType;
+            ResultPlan = resultPlan;
             ParameterType = parameterType;
             Method = method;
             ParameterMap = parameterMap;

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/AdditionalCommandState.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/AdditionalCommandState.cs
@@ -1,4 +1,4 @@
-using Dapper.CodeAnalysis;
+﻿using Dapper.CodeAnalysis;
 using Dapper.Internal;
 using Microsoft.CodeAnalysis;
 using System;
@@ -56,7 +56,6 @@ internal readonly struct CommandProperty : IEquatable<CommandProperty>
             location is null ? default : new LocationSnapshot(location));
     }
 
-    // note: preserved exactly from the emit-time check it replaces, quirks and all
     private static bool HasPublicSettableInstanceMember(ITypeSymbol type, string name)
     {
         foreach (var member in type.GetMembers())
@@ -64,7 +63,7 @@ internal readonly struct CommandProperty : IEquatable<CommandProperty>
             if (member.IsStatic || member.Name != name || member.DeclaredAccessibility != Accessibility.Public) continue;
             return member.Kind switch
             {
-                SymbolKind.Field when member is IFieldSymbol field => field.IsReadOnly,
+                SymbolKind.Field when member is IFieldSymbol field => !field.IsReadOnly,
                 SymbolKind.Property when member is IPropertySymbol prop => prop.SetMethod is not null,
                 _ => false,
             };

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/InterceptorEnvironment.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/InterceptorEnvironment.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Dapper.CodeAnalysis.Model;
+
+/// <summary>
+/// The compilation-level facts the interceptor generator's output step needs, projected so
+/// the raw <c>Compilation</c> never feeds that step (which would re-run it on every edit).
+/// </summary>
+internal sealed class InterceptorEnvironment : IEquatable<InterceptorEnvironment>
+{
+    public bool AllowUnsafe { get; }
+    public string? AssemblyName { get; }
+    public bool HasInterceptsLocationAttribute { get; }
+    public bool NeedsCommandPrep { get; }
+    public string? BaseCommandFactoryName { get; } // [CommandFactory<T>] at module level, if any
+    public bool BaseFactoryCanConstruct { get; }
+    public EquatableArray<SpecialDbCommandType> SpecialCommandTypes { get; } // providers needing per-command setup
+    public ParamPlan SystemObjectPlan { get; } // the parameterless command-factory fallback
+
+    public InterceptorEnvironment(bool allowUnsafe, string? assemblyName, bool hasInterceptsLocationAttribute,
+        bool needsCommandPrep, string? baseCommandFactoryName, bool baseFactoryCanConstruct,
+        in EquatableArray<SpecialDbCommandType> specialCommandTypes, ParamPlan systemObjectPlan)
+    {
+        AllowUnsafe = allowUnsafe;
+        AssemblyName = assemblyName;
+        HasInterceptsLocationAttribute = hasInterceptsLocationAttribute;
+        NeedsCommandPrep = needsCommandPrep;
+        BaseCommandFactoryName = baseCommandFactoryName;
+        BaseFactoryCanConstruct = baseFactoryCanConstruct;
+        SpecialCommandTypes = specialCommandTypes;
+        SystemObjectPlan = systemObjectPlan;
+    }
+
+    public bool Equals(InterceptorEnvironment? other) => other is not null
+        && AllowUnsafe == other.AllowUnsafe
+        && string.Equals(AssemblyName, other.AssemblyName, StringComparison.Ordinal)
+        && HasInterceptsLocationAttribute == other.HasInterceptsLocationAttribute
+        && NeedsCommandPrep == other.NeedsCommandPrep
+        && string.Equals(BaseCommandFactoryName, other.BaseCommandFactoryName, StringComparison.Ordinal)
+        && BaseFactoryCanConstruct == other.BaseFactoryCanConstruct
+        && SpecialCommandTypes.Equals(other.SpecialCommandTypes)
+        && SystemObjectPlan.Equals(other.SystemObjectPlan);
+
+    public override bool Equals(object? obj) => Equals(obj as InterceptorEnvironment);
+    public override int GetHashCode()
+        => (AssemblyName is null ? 0 : StringComparer.Ordinal.GetHashCode(AssemblyName))
+        ^ SpecialCommandTypes.GetHashCode();
+}
+
+/// <summary>A provider command type that needs special per-command initialization.</summary>
+internal readonly struct SpecialDbCommandType : IEquatable<SpecialDbCommandType>
+{
+    public string TypeName { get; } // emitted (Append) form
+    public string ShortName { get; } // for the comment
+    public bool BindByName { get; }
+    public bool InitialLONGFetchSize { get; }
+
+    public SpecialDbCommandType(string typeName, string shortName, bool bindByName, bool initialLongFetchSize)
+    {
+        TypeName = typeName;
+        ShortName = shortName;
+        BindByName = bindByName;
+        InitialLONGFetchSize = initialLongFetchSize;
+    }
+
+    public bool Equals(SpecialDbCommandType other)
+        => string.Equals(TypeName, other.TypeName, StringComparison.Ordinal)
+        && string.Equals(ShortName, other.ShortName, StringComparison.Ordinal)
+        && BindByName == other.BindByName
+        && InitialLONGFetchSize == other.InitialLONGFetchSize;
+
+    public override bool Equals(object? obj) => obj is SpecialDbCommandType other && Equals(other);
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(TypeName);
+}

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/ParamPlan.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/ParamPlan.cs
@@ -1,0 +1,226 @@
+using Dapper.Internal;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Data;
+using static Dapper.Internal.Inspection;
+
+namespace Dapper.CodeAnalysis.Model;
+
+/// <summary>
+/// Everything command-factory emission needs about a parameter type, fully projected at parse
+/// time (see the model shape test: no symbols may be cached). Structural equality de-dupes
+/// command factories, replacing the old symbol-keyed dictionary.
+/// </summary>
+internal sealed class ParamPlan : IEquatable<ParamPlan>
+{
+    public string TypeName { get; } // emitted (Append) form; anonymous renders as the display string
+    public string DeclaredType { get; } // "object?" for anonymous types
+    public bool IsAnonymous { get; }
+    public bool IsReferenceType { get; }
+    public bool IsCancellationTokenType { get; }
+    public string? ShapeLambda { get; } // the Cast(args, ...) witness, anonymous types only
+    public bool IsCollection { get; } // multi-exec candidate
+    public string? CastType { get; }
+    public ParamPlan? Element { get; } // multi-exec element (one level only)
+    public EquatableArray<ParamMember> Members { get; }
+
+    private ParamPlan(string typeName, string declaredType, bool isAnonymous, bool isReferenceType,
+        bool isCancellationTokenType, string? shapeLambda, bool isCollection, string? castType,
+        ParamPlan? element, in EquatableArray<ParamMember> members)
+    {
+        TypeName = typeName;
+        DeclaredType = declaredType;
+        IsAnonymous = isAnonymous;
+        IsReferenceType = isReferenceType;
+        IsCancellationTokenType = isCancellationTokenType;
+        ShapeLambda = shapeLambda;
+        IsCollection = isCollection;
+        CastType = castType;
+        Element = element;
+        Members = members;
+    }
+
+    public static ParamPlan? Create(ITypeSymbol? type) => Create(type, allowCollection: true);
+
+    private static ParamPlan? Create(ITypeSymbol? type, bool allowCollection)
+    {
+        if (type is null) return null;
+
+        var typeName = CodeWriter.GetAppendTypeName(type);
+        var declaredType = type.IsAnonymousType ? "object?" : CodeWriter.GetTypeName(type);
+
+        string? shapeLambda = null;
+        if (type.IsAnonymousType)
+        {
+            var sb = new CodeWriter();
+            AppendShapeLambda(sb, type);
+            shapeLambda = sb.ToString();
+        }
+
+        bool isCollection = false;
+        string? castType = null;
+        ParamPlan? element = null;
+        if (allowCollection && Inspection.IsCollectionType(type, out var elementType, out var castTypeValue))
+        {
+            isCollection = true;
+            castType = castTypeValue;
+            element = Create(elementType, allowCollection: false);
+        }
+
+        EquatableArray<ParamMember> members = default;
+        var memberMap = MemberMap.CreateForParameters(type);
+        if (memberMap is not null && !memberMap.Members.IsDefaultOrEmpty)
+        {
+            var arr = new ParamMember[memberMap.Members.Length];
+            for (int i = 0; i < arr.Length; i++)
+            {
+                arr[i] = ParamMember.Create(memberMap.Members[i]);
+            }
+            members = new EquatableArray<ParamMember>(arr);
+        }
+
+        return new(typeName, declaredType, type.IsAnonymousType, type.IsReferenceType,
+            Inspection.IsCancellationToken(type), shapeLambda, isCollection, castType, element, members);
+    }
+
+    private static void AppendShapeLambda(CodeWriter sb, ITypeSymbol parameterType)
+    {
+        var members = parameterType.GetMembers();
+        int count = CodeWriter.CountGettableInstanceMembers(members);
+        switch (count)
+        {
+            case 0:
+                sb.Append("static () => (object?)null");
+                break;
+            default:
+                bool first = true;
+                sb.Append("static () => new {");
+                foreach (var member in members)
+                {
+                    if (CodeWriter.IsGettableInstanceMember(member, out var type))
+                    {
+                        sb.Append(first ? " " : ", ").Append(member.Name).Append(" = default(").Append(type).Append(")");
+                        if (type.IsReferenceType && type.NullableAnnotation == NullableAnnotation.None)
+                        {
+                            sb.Append("!");
+                        }
+                        first = false;
+                    }
+                }
+                sb.Append(" }");
+                break;
+        }
+    }
+
+    public bool Equals(ParamPlan? other) => other is not null
+        && string.Equals(TypeName, other.TypeName, StringComparison.Ordinal)
+        && string.Equals(DeclaredType, other.DeclaredType, StringComparison.Ordinal)
+        && IsAnonymous == other.IsAnonymous
+        && IsReferenceType == other.IsReferenceType
+        && IsCancellationTokenType == other.IsCancellationTokenType
+        && string.Equals(ShapeLambda, other.ShapeLambda, StringComparison.Ordinal)
+        && IsCollection == other.IsCollection
+        && string.Equals(CastType, other.CastType, StringComparison.Ordinal)
+        && Equals(Element, other.Element)
+        && Members.Equals(other.Members);
+
+    public override bool Equals(object? obj) => Equals(obj as ParamPlan);
+    public override int GetHashCode()
+    {
+        int hash = StringComparer.Ordinal.GetHashCode(TypeName);
+        hash = (hash * -47) + Members.GetHashCode();
+        return hash;
+    }
+    public override string ToString() => TypeName;
+}
+
+/// <summary>A parameter member as plain data, with the Add-mode sizing decisions precomputed.</summary>
+internal readonly struct ParamMember : IEquatable<ParamMember>
+{
+    public bool IsMapped { get; }
+    public bool IsCancellation { get; }
+    public bool IsRowCount { get; }
+    public string CodeName { get; }
+    public string DbName { get; }
+    public ParameterDirection Direction { get; }
+    public bool IsDbString { get; }
+    public bool HasDbType { get; } // no DbType => cannot Prepare
+    public string? DbTypeName { get; } // for "p.DbType = global::System.Data.DbType.X;"
+    public int? EffectiveSize { get; } // after the [n]varchar(max) adjustment
+    public bool UseSetValueWithDefaultSize { get; }
+    public byte? Precision { get; }
+    public byte? Scale { get; }
+    public string TypeName { get; } // emitted (Append) form, for Parse<T> in post-process
+
+    private ParamMember(bool isMapped, bool isCancellation, bool isRowCount, string codeName, string dbName,
+        ParameterDirection direction, bool isDbString, bool hasDbType, string? dbTypeName, int? effectiveSize,
+        bool useSetValueWithDefaultSize, byte? precision, byte? scale, string typeName)
+    {
+        IsMapped = isMapped;
+        IsCancellation = isCancellation;
+        IsRowCount = isRowCount;
+        CodeName = codeName;
+        DbName = dbName;
+        Direction = direction;
+        IsDbString = isDbString;
+        HasDbType = hasDbType;
+        DbTypeName = dbTypeName;
+        EffectiveSize = effectiveSize;
+        UseSetValueWithDefaultSize = useSetValueWithDefaultSize;
+        Precision = precision;
+        Scale = scale;
+        TypeName = typeName;
+    }
+
+    public static ParamMember Create(in ElementMember member)
+    {
+        if (!member.IsMapped)
+        {
+            return new(false, false, false, "", "", default, false, false, null, null, false, null, null, "");
+        }
+        var dbType = member.GetDbType(out _);
+        var size = member.TryGetValue<int>("Size");
+        bool useSetValueWithDefaultSize = false;
+        if (dbType is not null && size is null)
+        {
+            switch (dbType.GetValueOrDefault())
+            {
+                case DbType.Binary:
+                case DbType.String:
+                case DbType.AnsiString:
+                    if (member.CodeType!.SpecialType == SpecialType.System_String)
+                    {
+                        useSetValueWithDefaultSize = true;
+                    }
+                    else
+                    {
+                        size = -1; // default to [n]varchar(max)/varbinary(max)
+                    }
+                    break;
+            }
+        }
+        return new(true, member.IsCancellation, member.IsRowCount, member.CodeName, member.DbName,
+            member.Direction, member.DapperSpecialType is DapperSpecialType.DbString,
+            dbType is not null, dbType?.ToString(), size, useSetValueWithDefaultSize,
+            member.TryGetValue<byte>("Precision"), member.TryGetValue<byte>("Scale"),
+            CodeWriter.GetAppendTypeName(member.CodeType!));
+    }
+
+    public bool Equals(ParamMember other) => IsMapped == other.IsMapped
+        && IsCancellation == other.IsCancellation
+        && IsRowCount == other.IsRowCount
+        && string.Equals(CodeName, other.CodeName, StringComparison.Ordinal)
+        && string.Equals(DbName, other.DbName, StringComparison.Ordinal)
+        && Direction == other.Direction
+        && IsDbString == other.IsDbString
+        && HasDbType == other.HasDbType
+        && string.Equals(DbTypeName, other.DbTypeName, StringComparison.Ordinal)
+        && EffectiveSize == other.EffectiveSize
+        && UseSetValueWithDefaultSize == other.UseSetValueWithDefaultSize
+        && Precision == other.Precision
+        && Scale == other.Scale
+        && string.Equals(TypeName, other.TypeName, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is ParamMember other && Equals(other);
+    public override int GetHashCode() => IsMapped ? StringComparer.Ordinal.GetHashCode(CodeName) : 0;
+}

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/RowPlan.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/RowPlan.cs
@@ -1,0 +1,185 @@
+﻿using Dapper.Internal;
+using Microsoft.CodeAnalysis;
+using System;
+using static Dapper.Internal.Inspection;
+
+namespace Dapper.CodeAnalysis.Model;
+
+/// <summary>
+/// Everything row-factory emission needs about a result type, fully projected at parse time
+/// (see the model shape test: no symbols may be cached). Structural equality is what de-dupes
+/// row factories, replacing the old symbol+columns dictionary key.
+/// </summary>
+internal sealed class RowPlan : IEquatable<RowPlan>
+{
+    public string TypeName { get; } // emitted (Append) form
+    public string NonNullTypeName { get; } // for "T result = new();" when the type was annotated
+    public string? InbuiltHelper { get; } // e.g. "Value<int>()": no custom factory is emitted
+    public bool UseConstructor { get; }
+    public bool UseFactoryMethod { get; }
+    public string? FactoryMethodName { get; }
+    public bool UseDeferredConstruction { get; }
+    public int TotalMemberCount { get; } // the flexible-token offset: counts unmapped members too
+    public EquatableArray<RowMember> Members { get; } // the query-column-mapped view
+    public EquatableArray<string> QueryColumns { get; }
+
+    private RowPlan(string typeName, string nonNullTypeName, string? inbuiltHelper,
+        bool useConstructor, bool useFactoryMethod, string? factoryMethodName, bool useDeferredConstruction,
+        int totalMemberCount, in EquatableArray<RowMember> members, in EquatableArray<string> queryColumns)
+    {
+        TypeName = typeName;
+        NonNullTypeName = nonNullTypeName;
+        InbuiltHelper = inbuiltHelper;
+        UseConstructor = useConstructor;
+        UseFactoryMethod = useFactoryMethod;
+        FactoryMethodName = factoryMethodName;
+        UseDeferredConstruction = useDeferredConstruction;
+        TotalMemberCount = totalMemberCount;
+        Members = members;
+        QueryColumns = queryColumns;
+    }
+
+    public static RowPlan? Create(ITypeSymbol? type, in EquatableArray<string> queryColumns)
+    {
+        if (type is null) return null;
+
+        var typeName = CodeWriter.GetAppendTypeName(type);
+        var nonNullTypeName = type.NullableAnnotation == NullableAnnotation.Annotated
+            ? CodeWriter.GetAppendTypeName(type.WithNullableAnnotation(NullableAnnotation.NotAnnotated))
+            : typeName;
+
+        if (CodeWriter.IsInbuiltResultType(type, out var helper))
+        {   // no custom factory will be emitted; the rest is irrelevant
+            return new(typeName, nonNullTypeName, helper, false, false, null, false, 0, default, queryColumns);
+        }
+
+        var map = MemberMap.CreateForResults(type);
+        if (map is null)
+        {
+            return new(typeName, nonNullTypeName, null, false, false, null, false, 0, default, queryColumns);
+        }
+
+        var mapped = map.MapQueryColumns(queryColumns);
+        var members = new RowMember[mapped.Length];
+        bool hasInitOnly = false, hasRequired = false, hasGetOnly = false;
+        for (int i = 0; i < mapped.Length; i++)
+        {
+            var member = RowMember.Create(mapped[i]);
+            members[i] = member;
+            if (member.IsMapped)
+            {
+                hasInitOnly |= member.IsInitOnly;
+                hasRequired |= member.IsRequired;
+                hasGetOnly |= member is { IsGettable: true, IsSettable: false, IsInitOnly: false };
+            }
+        }
+        bool useConstructor = map.Constructor is not null;
+        bool useFactoryMethod = map.FactoryMethod is not null;
+        bool useDeferred = useConstructor || useFactoryMethod || hasInitOnly || hasGetOnly || hasRequired;
+
+        return new(typeName, nonNullTypeName, null, useConstructor, useFactoryMethod,
+            map.FactoryMethod?.Name, useDeferred, map.Members.Length,
+            new EquatableArray<RowMember>(members), queryColumns);
+    }
+
+    public bool Equals(RowPlan? other) => other is not null
+        && string.Equals(TypeName, other.TypeName, StringComparison.Ordinal)
+        && string.Equals(NonNullTypeName, other.NonNullTypeName, StringComparison.Ordinal)
+        && string.Equals(InbuiltHelper, other.InbuiltHelper, StringComparison.Ordinal)
+        && UseConstructor == other.UseConstructor
+        && UseFactoryMethod == other.UseFactoryMethod
+        && string.Equals(FactoryMethodName, other.FactoryMethodName, StringComparison.Ordinal)
+        && UseDeferredConstruction == other.UseDeferredConstruction
+        && TotalMemberCount == other.TotalMemberCount
+        && Members.Equals(other.Members)
+        && QueryColumns.Equals(other.QueryColumns);
+
+    public override bool Equals(object? obj) => Equals(obj as RowPlan);
+    public override int GetHashCode()
+    {
+        int hash = StringComparer.Ordinal.GetHashCode(TypeName);
+        hash = (hash * -47) + Members.GetHashCode();
+        hash = (hash * -47) + QueryColumns.GetHashCode();
+        return hash;
+    }
+    public override string ToString() => TypeName;
+}
+
+/// <summary>A result member as plain data (unmapped placeholders keep token positions).</summary>
+internal readonly struct RowMember : IEquatable<RowMember>
+{
+    public bool IsMapped { get; }
+    public string CodeName { get; }
+    public string DbName { get; }
+    public string TypeName { get; } // emitted (Append) form of the member type
+    public string NonNullTypeName { get; } // MakeNonNullable form, for typeof(...) tests
+    public string AnnotatedTypeName { get; } // GetTypeName(WithNullableAnnotation(Annotated)), for the null-check cast
+    public bool CouldBeNullable { get; }
+    public string? ReaderMethod { get; } // e.g. GetInt32; null = GetFieldValue<T>
+    public int? ConstructorParameterOrder { get; }
+    public int? FactoryMethodParameterOrder { get; }
+    public bool IsInitOnly { get; }
+    public bool IsRequired { get; }
+    public bool IsGettable { get; }
+    public bool IsSettable { get; }
+    public bool NeedsDefaultBang { get; } // reference type, not annotated: "default!"
+
+    private RowMember(bool isMapped, string codeName, string dbName, string typeName, string nonNullTypeName,
+        string annotatedTypeName, bool couldBeNullable, string? readerMethod, int? constructorParameterOrder,
+        int? factoryMethodParameterOrder, bool isInitOnly, bool isRequired, bool isGettable, bool isSettable,
+        bool needsDefaultBang)
+    {
+        IsMapped = isMapped;
+        CodeName = codeName;
+        DbName = dbName;
+        TypeName = typeName;
+        NonNullTypeName = nonNullTypeName;
+        AnnotatedTypeName = annotatedTypeName;
+        CouldBeNullable = couldBeNullable;
+        ReaderMethod = readerMethod;
+        ConstructorParameterOrder = constructorParameterOrder;
+        FactoryMethodParameterOrder = factoryMethodParameterOrder;
+        IsInitOnly = isInitOnly;
+        IsRequired = isRequired;
+        IsGettable = isGettable;
+        IsSettable = isSettable;
+        NeedsDefaultBang = needsDefaultBang;
+    }
+
+    public static RowMember Create(in ElementMember member)
+    {
+        if (!member.IsMapped)
+        {
+            return new(false, "", "", "", "", "", false, null, null, null, false, false, false, false, false);
+        }
+        var memberType = member.CodeType!;
+        member.GetDbType(out var readerMethod);
+        return new(true, member.CodeName, member.DbName,
+            CodeWriter.GetAppendTypeName(memberType),
+            CodeWriter.GetAppendTypeName(Inspection.MakeNonNullable(memberType)),
+            CodeWriter.GetTypeName(memberType.WithNullableAnnotation(NullableAnnotation.Annotated)),
+            Inspection.CouldBeNullable(memberType), readerMethod,
+            member.ConstructorParameterOrder, member.FactoryMethodParameterOrder,
+            member.IsInitOnly, member.IsRequired, member.IsGettable, member.IsSettable,
+            memberType.IsReferenceType && memberType.NullableAnnotation == NullableAnnotation.NotAnnotated);
+    }
+
+    public bool Equals(RowMember other) => IsMapped == other.IsMapped
+        && string.Equals(CodeName, other.CodeName, StringComparison.Ordinal)
+        && string.Equals(DbName, other.DbName, StringComparison.Ordinal)
+        && string.Equals(TypeName, other.TypeName, StringComparison.Ordinal)
+        && string.Equals(NonNullTypeName, other.NonNullTypeName, StringComparison.Ordinal)
+        && string.Equals(AnnotatedTypeName, other.AnnotatedTypeName, StringComparison.Ordinal)
+        && CouldBeNullable == other.CouldBeNullable
+        && string.Equals(ReaderMethod, other.ReaderMethod, StringComparison.Ordinal)
+        && ConstructorParameterOrder == other.ConstructorParameterOrder
+        && FactoryMethodParameterOrder == other.FactoryMethodParameterOrder
+        && IsInitOnly == other.IsInitOnly
+        && IsRequired == other.IsRequired
+        && IsGettable == other.IsGettable
+        && IsSettable == other.IsSettable
+        && NeedsDefaultBang == other.NeedsDefaultBang;
+
+    public override bool Equals(object? obj) => obj is RowMember other && Equals(other);
+    public override int GetHashCode() => IsMapped ? StringComparer.Ordinal.GetHashCode(CodeName) : 0;
+}

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/ParseState.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/ParseState.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Dapper.CodeAnalysis.Model;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using System;
@@ -66,14 +67,14 @@ internal readonly struct GenerateState
 {
     public GenerateState(GenerateContextProxy proxy)
     {
-        Compilation = proxy.Compilation;
+        Environment = DapperInterceptorGenerator.CreateEnvironment(proxy.Compilation);
         Nodes = proxy.Nodes;
         ctx = default;
         this.proxy = proxy;
     }
-    public GenerateState(SourceProductionContext ctx, in (Compilation Compilation, ImmutableArray<SourceState> Nodes) state)
+    public GenerateState(SourceProductionContext ctx, in (InterceptorEnvironment Environment, ImmutableArray<SourceState> Nodes) state)
     {
-        Compilation = state.Compilation;
+        Environment = state.Environment;
         Nodes = state.Nodes;
         this.ctx = ctx;
         proxy = null;
@@ -81,7 +82,7 @@ internal readonly struct GenerateState
     private readonly SourceProductionContext ctx;
     private readonly GenerateContextProxy? proxy;
     public readonly ImmutableArray<SourceState> Nodes;
-    public readonly Compilation Compilation;
+    public readonly InterceptorEnvironment Environment;
     public readonly GeneratorContext GeneratorContext = new();
 
     internal void ReportDiagnostic(Diagnostic diagnostic)
@@ -108,12 +109,6 @@ internal readonly struct GenerateState
         }
     }
 
-    // see https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md#file-paths
-    internal string GetInterceptorFilePath(SyntaxTree? tree)
-    {
-        if (tree is null) return "";
-        return Compilation.Options.SourceReferenceResolver?.NormalizePath(tree.FilePath, baseFilePath: null) ?? tree.FilePath;
-    }
 }
 
 

--- a/src/Dapper.AOT.Analyzers/Internal/CodeWriter.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/CodeWriter.cs
@@ -335,16 +335,17 @@ internal sealed class CodeWriter
         return s;
     }
 
-    internal CodeWriter AppendReader(ITypeSymbol? resultType, RowReaderState readers, OperationFlags flags, in EquatableArray<string> queryColumns)
+    internal CodeWriter AppendReader(RowPlan? plan, RowReaderState readers, OperationFlags flags)
     {
-        if (IsInbuiltResultType(resultType, out var helper))
+        if (plan is null)
+        {   // an untyped result is read as dynamic
+            return Append("global::Dapper.RowFactory.Inbuilt.Dynamic");
+        }
+        if (plan.InbuiltHelper is { } helper)
         {
             return Append("global::Dapper.RowFactory.Inbuilt.").Append(helper);
         }
-        else
-        {
-            return Append("RowFactory").Append(readers.GetIndex(resultType!, flags, queryColumns)).Append(".Instance");
-        }
+        return Append("RowFactory").Append(readers.GetIndex(plan, flags)).Append(".Instance");
     }
 
     internal static bool IsInbuiltResultType(ITypeSymbol? type, out string? helper)

--- a/src/Dapper.AOT.Analyzers/Internal/CommandFactoryState.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/CommandFactoryState.cs
@@ -7,12 +7,12 @@ using System.Linq;
 
 namespace Dapper.Internal;
 
-internal readonly struct CommandFactoryState : IEnumerable<(ITypeSymbol Type, string Map, int Index, int CacheCount, AdditionalCommandState? AdditionalCommandState)>
+internal readonly struct CommandFactoryState : IEnumerable<(ParamPlan Plan, string Map, int Index, int CacheCount, AdditionalCommandState? AdditionalCommandState)>
 {
 
-    public CommandFactoryState(Compilation compilation) => systemObject = compilation.GetSpecialType(SpecialType.System_Object);
-    private readonly ITypeSymbol systemObject;
-    private readonly Dictionary<(ITypeSymbol Type, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState), (int Index, int CacheCount)> parameterTypes = new(ParameterTypeMapComparer.Instance);
+    public CommandFactoryState(Compilation compilation) => systemObject = ParamPlan.Create(compilation.GetSpecialType(SpecialType.System_Object))!;
+    private readonly ParamPlan systemObject;
+    private readonly Dictionary<(ParamPlan Plan, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState), (int Index, int CacheCount)> parameterTypes = new(ParameterTypeMapComparer.Instance);
 
     public int Count()
     {
@@ -25,22 +25,22 @@ internal readonly struct CommandFactoryState : IEnumerable<(ITypeSymbol Type, st
         return total;
     }
 
-    public IEnumerator<(ITypeSymbol Type, string Map, int Index, int CacheCount, AdditionalCommandState? AdditionalCommandState)> GetEnumerator()
+    public IEnumerator<(ParamPlan Plan, string Map, int Index, int CacheCount, AdditionalCommandState? AdditionalCommandState)> GetEnumerator()
     {
         // retain discovery order
-        return parameterTypes.OrderBy(x => x.Value.Index).Select(x => (x.Key.Type, x.Key.Map, x.Value.Index, x.Value.CacheCount, x.Key.AdditionalCommandState)).GetEnumerator();
+        return parameterTypes.OrderBy(x => x.Value.Index).Select(x => (x.Key.Plan, x.Key.Map, x.Value.Index, x.Value.CacheCount, x.Key.AdditionalCommandState)).GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public int GetIndex(ITypeSymbol type, string map, bool cache, AdditionalCommandState? additionalCommandState, out int? subIndex)
+    public int GetIndex(ParamPlan plan, string map, bool cache, AdditionalCommandState? additionalCommandState, out int? subIndex)
     {
-        if (string.IsNullOrWhiteSpace(map) && type.IsReferenceType)
+        if (string.IsNullOrWhiteSpace(map) && plan.IsReferenceType)
         {
             // just use object if there's nothing to map
-            type = systemObject;
+            plan = systemObject;
         }
-        var key = (type!, map, cache, additionalCommandState);
+        var key = (plan!, map, cache, additionalCommandState);
         int index;
         if (parameterTypes.TryGetValue(key, out var value))
         {
@@ -64,22 +64,22 @@ internal readonly struct CommandFactoryState : IEnumerable<(ITypeSymbol Type, st
         return index;
     }
 
-    private sealed class ParameterTypeMapComparer : IEqualityComparer<(ITypeSymbol Type, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState)>
+    private sealed class ParameterTypeMapComparer : IEqualityComparer<(ParamPlan Plan, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState)>
     {
         public static readonly ParameterTypeMapComparer Instance = new();
         private ParameterTypeMapComparer() { }
 
-        public bool Equals((ITypeSymbol Type, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState) x, (ITypeSymbol Type, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState) y)
+        public bool Equals((ParamPlan Plan, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState) x, (ParamPlan Plan, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState) y)
             => StringComparer.InvariantCultureIgnoreCase.Equals(x.Map, y.Map)
-            && SymbolEqualityComparer.Default.Equals(x.Type, y.Type)
+            && x.Plan.Equals(y.Plan)
             && Equals(x.AdditionalCommandState, y.AdditionalCommandState)
             && x.Cached == y.Cached;
 
-        public int GetHashCode((ITypeSymbol Type, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState) obj)
+        public int GetHashCode((ParamPlan Plan, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState) obj)
             => (StringComparer.InvariantCultureIgnoreCase.GetHashCode(obj.Map)
-            ^ SymbolEqualityComparer.Default.GetHashCode(obj.Type))
+            ^ obj.Plan.GetHashCode())
             ^ (obj.AdditionalCommandState is null ? 0 : obj.AdditionalCommandState.GetHashCode())
             * (obj.Cached ? -1 : 1);
-            
+
     }
 }

--- a/src/Dapper.AOT.Analyzers/Internal/CommandFactoryState.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/CommandFactoryState.cs
@@ -10,7 +10,7 @@ namespace Dapper.Internal;
 internal readonly struct CommandFactoryState : IEnumerable<(ParamPlan Plan, string Map, int Index, int CacheCount, AdditionalCommandState? AdditionalCommandState)>
 {
 
-    public CommandFactoryState(Compilation compilation) => systemObject = ParamPlan.Create(compilation.GetSpecialType(SpecialType.System_Object))!;
+    public CommandFactoryState(ParamPlan systemObjectPlan) => systemObject = systemObjectPlan;
     private readonly ParamPlan systemObject;
     private readonly Dictionary<(ParamPlan Plan, string Map, bool Cached, AdditionalCommandState? AdditionalCommandState), (int Index, int CacheCount)> parameterTypes = new(ParameterTypeMapComparer.Instance);
 

--- a/src/Dapper.AOT.Analyzers/Internal/RowReaderState.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/RowReaderState.cs
@@ -1,31 +1,30 @@
 ﻿using Dapper.CodeAnalysis.Model;
-using Microsoft.CodeAnalysis;
+using Dapper.CodeAnalysis;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 
 namespace Dapper.Internal;
 
-internal readonly struct RowReaderState : IEnumerable<(ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns, int Index)>
+internal readonly struct RowReaderState : IEnumerable<(RowPlan Plan, OperationFlags Flags, int Index)>
 {
     public RowReaderState() { }
-    private readonly Dictionary<(ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns), int> resultTypes = new (KeyComparer.Instance);
+    private readonly Dictionary<(RowPlan Plan, OperationFlags Flags), int> resultTypes = new(KeyComparer.Instance);
 
     public int Count() => resultTypes.Count;
 
-    public IEnumerator<(ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns, int Index)> GetEnumerator()
+    public IEnumerator<(RowPlan Plan, OperationFlags Flags, int Index)> GetEnumerator()
     {
         // retain discovery order
-        return resultTypes.OrderBy(x => x.Value).Select(x => (x.Key.Type, x.Key.Flags, x.Key.QueryColumns, x.Value)).GetEnumerator();
+        return resultTypes.OrderBy(x => x.Value).Select(x => (x.Key.Plan, x.Key.Flags, x.Value)).GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    public int GetIndex(ITypeSymbol type, OperationFlags flags, EquatableArray<string> queryColumns)
+    public int GetIndex(RowPlan plan, OperationFlags flags)
     {
         const OperationFlags SIGNIFICANT_FLAGS = OperationFlags.StrictTypes; // restrict to flags that impact the reader
-        var key = (type, flags & SIGNIFICANT_FLAGS, queryColumns);
+        var key = (plan, flags & SIGNIFICANT_FLAGS);
         if (!resultTypes.TryGetValue(key, out var index))
         {
             resultTypes.Add(key, index = resultTypes.Count);
@@ -33,15 +32,15 @@ internal readonly struct RowReaderState : IEnumerable<(ITypeSymbol Type, Operati
         return index;
     }
 
-    private sealed class KeyComparer : IEqualityComparer<(ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns)>
+    private sealed class KeyComparer : IEqualityComparer<(RowPlan Plan, OperationFlags Flags)>
     {
         private KeyComparer() { }
         public static readonly KeyComparer Instance = new();
 
-        bool IEqualityComparer<(ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns)>.Equals((ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns) x, (ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns) y)
-            => SymbolEqualityComparer.Default.Equals(x.Type, y.Type) && x.Flags == y.Flags && x.QueryColumns.Equals(y.QueryColumns);
+        bool IEqualityComparer<(RowPlan Plan, OperationFlags Flags)>.Equals((RowPlan Plan, OperationFlags Flags) x, (RowPlan Plan, OperationFlags Flags) y)
+            => x.Plan.Equals(y.Plan) && x.Flags == y.Flags;
 
-        int IEqualityComparer<(ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns)>.GetHashCode((ITypeSymbol Type, OperationFlags Flags, EquatableArray<string> QueryColumns) obj)
-            => SymbolEqualityComparer.Default.GetHashCode(obj.Type) ^ (int)obj.Flags ^ obj.QueryColumns.GetHashCode();
+        int IEqualityComparer<(RowPlan Plan, OperationFlags Flags)>.GetHashCode((RowPlan Plan, OperationFlags Flags) obj)
+            => obj.Plan.GetHashCode() ^ (int)obj.Flags;
     }
 }

--- a/test/Dapper.AOT.Test/CommandPropertyMemberTests.cs
+++ b/test/Dapper.AOT.Test/CommandPropertyMemberTests.cs
@@ -1,0 +1,43 @@
+using Dapper.AOT.Test.TestCommon;
+using Dapper.CodeAnalysis.Model;
+using Microsoft.CodeAnalysis;
+using System.Linq;
+using Xunit;
+
+namespace Dapper.AOT.Test;
+
+/// <summary>
+/// The [CommandProperty] member probe: a public mutable field is assignable, a readonly
+/// field is not (this was inverted for a long time - it never fired in anger because real
+/// ADO.NET command types expose these knobs as properties).
+/// </summary>
+public class CommandPropertyMemberTests
+{
+    const string Source = """
+        public class SomeCommandType
+        {
+            public int MutableField;
+            public readonly int ReadOnlyField;
+            public int SettableProperty { get; set; }
+            public int GetOnlyProperty { get; }
+            public static int StaticProperty { get; set; }
+        }
+        """;
+
+    static bool MemberExists(string name)
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(Source, "cmdprop_test", "Input.cs");
+        var type = (INamedTypeSymbol)compilation.GetSymbolsWithName("SomeCommandType").Single();
+        return CommandProperty.Create(type, name, 42, null).MemberExists;
+    }
+
+    [Theory]
+    [InlineData("MutableField", true)]
+    [InlineData("ReadOnlyField", false)]
+    [InlineData("SettableProperty", true)]
+    [InlineData("GetOnlyProperty", false)]
+    [InlineData("StaticProperty", false)]
+    [InlineData("DoesNotExist", false)]
+    public void MemberProbeReflectsAssignability(string name, bool expected)
+        => Assert.Equal(expected, MemberExists(name));
+}

--- a/test/Dapper.AOT.Test/IncrementalCachingTests.cs
+++ b/test/Dapper.AOT.Test/IncrementalCachingTests.cs
@@ -1,0 +1,122 @@
+﻿using Dapper.AOT.Test.TestCommon;
+using Dapper.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Linq;
+using Xunit;
+
+namespace Dapper.AOT.Test;
+
+/// <summary>
+/// Proves the incremental pipeline actually caches: the whole point of the plain-data model
+/// (see ModelShapeTests) is that an edit which does not change any Dapper call-site must not
+/// re-run the output step - and a real edit must. Both directions are asserted, so this test
+/// is known to be able to fail.
+/// </summary>
+public class IncrementalCachingTests
+{
+    const string DapperUsage = """
+        using Dapper;
+        using System.Data.Common;
+
+        [module: DapperAot]
+
+        public static class Program
+        {
+            public static Customer Get(DbConnection connection, int id)
+                => connection.QueryFirst<Customer>("select Id, Name from Customers where Id = @id", new { id });
+        }
+        public class Customer
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = "";
+        }
+        """;
+
+    const string Unrelated = """
+        public static class Unrelated
+        {
+            public static int Value => 1;
+        }
+        """;
+
+    static (GeneratorDriver Driver, Compilation Compilation) Setup()
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(DapperUsage, "incremental_test", "Usage.cs")
+            .AddSyntaxTrees(CSharpSyntaxTree.ParseText(Unrelated, RoslynTestHelpers.ParseOptionsLatestLangVer).WithFilePath("Unrelated.cs"));
+        var generator = new DapperInterceptorGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [generator.AsSourceGenerator()],
+            parseOptions: RoslynTestHelpers.ParseOptionsLatestLangVer,
+            driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+        driver = driver.RunGenerators(compilation);
+        return (driver, compilation);
+    }
+
+    static string GetOutput(GeneratorDriver driver)
+        => driver.GetRunResult().Results.Single().GeneratedSources.Single().SourceText.ToString();
+
+    static Compilation ReplaceTree(Compilation compilation, string filePath, string newSource)
+    {
+        var oldTree = compilation.SyntaxTrees.Single(t => t.FilePath == filePath);
+        var newTree = CSharpSyntaxTree.ParseText(newSource, RoslynTestHelpers.ParseOptionsLatestLangVer).WithFilePath(filePath);
+        return compilation.ReplaceSyntaxTree(oldTree, newTree);
+    }
+
+    [Fact]
+    public void UnrelatedEditDoesNotRerunTheOutputStep()
+    {
+        var (driver, compilation) = Setup();
+        var baseline = GetOutput(driver);
+        Assert.Contains("QueryFirst", baseline); // sanity: we generated something real
+
+        compilation = ReplaceTree(compilation, "Unrelated.cs", Unrelated.Replace("=> 1", "=> 2"));
+        driver = driver.RunGenerators(compilation);
+
+        var result = driver.GetRunResult().Results.Single();
+        var outputs = result.TrackedOutputSteps.SelectMany(kv => kv.Value).SelectMany(step => step.Outputs).ToArray();
+        Assert.NotEmpty(outputs);
+        Assert.All(outputs, output => Assert.True(
+            output.Reason is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged,
+            $"output step re-ran: {output.Reason}"));
+        Assert.Equal(baseline, GetOutput(driver));
+    }
+
+    [Fact] // the sharpest case: the *same file* is edited, so Parse re-runs and produces new
+    // state instances - only the states' structural equality stops the output re-running
+    public void SameFileEditBelowTheCallSiteDoesNotRerunTheOutputStep()
+    {
+        var (driver, compilation) = Setup();
+        var baseline = GetOutput(driver);
+
+        // note: below the call-site, so the interceptor location does not move
+        compilation = ReplaceTree(compilation, "Usage.cs", DapperUsage + "// trailing comment");
+        driver = driver.RunGenerators(compilation);
+
+        var result = driver.GetRunResult().Results.Single();
+        var outputs = result.TrackedOutputSteps.SelectMany(kv => kv.Value).SelectMany(step => step.Outputs).ToArray();
+        Assert.NotEmpty(outputs);
+        Assert.All(outputs, output => Assert.True(
+            output.Reason is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged,
+            $"output step re-ran: {output.Reason}"));
+        Assert.Equal(baseline, GetOutput(driver));
+    }
+
+    [Fact]
+    public void RealEditDoesRerunTheOutputStep()
+    {
+        var (driver, compilation) = Setup();
+        var baseline = GetOutput(driver);
+
+        // note the SQL text itself flows through as a runtime argument, so the edit must be
+        // one that changes the generated *shape*: add a bindable member to the row type
+        compilation = ReplaceTree(compilation, "Usage.cs", DapperUsage.Replace("public int Id { get; set; }", "public int Id { get; set; } public int Extra { get; set; }"));
+        driver = driver.RunGenerators(compilation);
+
+        var result = driver.GetRunResult().Results.Single();
+        var outputs = result.TrackedOutputSteps.SelectMany(kv => kv.Value).SelectMany(step => step.Outputs).ToArray();
+        Assert.NotEmpty(outputs);
+        Assert.Contains(outputs, output => output.Reason is IncrementalStepRunReason.Modified or IncrementalStepRunReason.New);
+        Assert.NotEqual(baseline, GetOutput(driver));
+    }
+}

--- a/test/Dapper.AOT.Test/ModelShapeTests.cs
+++ b/test/Dapper.AOT.Test/ModelShapeTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -21,7 +21,10 @@ public class ModelShapeTests
 
     public static IEnumerable<object[]> ModelTypes()
         => typeof(Dapper.CodeAnalysis.DapperAnalyzer).Assembly.GetTypes()
-            .Where(t => t.Namespace == ModelNamespace && !t.IsEnum && !IsCompilerGenerated(t))
+            .Where(t => (t.Namespace == ModelNamespace
+                    // the cached pipeline states themselves are also model, wherever they live
+                    || typeof(Dapper.CodeAnalysis.DapperInterceptorGenerator.SourceState).IsAssignableFrom(t))
+                && !t.IsEnum && !IsCompilerGenerated(t))
             .Select(t => new object[] { t });
 
     static bool IsCompilerGenerated(Type type) => type.Name.StartsWith("<");
@@ -79,7 +82,15 @@ public class ModelShapeTests
     [Theory, MemberData(nameof(ModelTypes))]
     public void ModelTypeIsEquatable(Type type)
     {
-        if (type.IsInterface || type.IsAbstract || type.IsNested) return; // (nested helpers like enumerators are not cached values)
+        if (type.IsInterface || type.IsAbstract || type.Name == "Enumerator") return; // (the enumerator helper is not a cached value)
+        if (typeof(Dapper.CodeAnalysis.DapperInterceptorGenerator.SourceState).IsAssignableFrom(type)
+            || type.IsNested)
+        {
+            // nested/state types use Equals overrides rather than IEquatable; the override is what matters
+            var equalsMethod = type.GetMethod("Equals", [type]);
+            Assert.True(equalsMethod is not null, type.Name + " should declare structural equality");
+            return;
+        }
         // structural equality is what makes the incremental cache work at all
         var equatable = typeof(IEquatable<>).MakeGenericType(type);
         Assert.True(equatable.IsAssignableFrom(type), $"{type.Name} should implement IEquatable<{type.Name}>");


### PR DESCRIPTION
Stacked on #187; completes the capture-model rework. The two remaining cached symbols become plans, and the output step stops taking the raw `Compilation`:

- **`RowPlan`/`RowMember`**: everything row-factory emission reads — member db-names/types/reader-methods, constructor/factory choice, deferred-construction facts, the inbuilt-helper decision, query-column mapping — projected at parse. `RowReaderState` de-dupes on plan equality instead of the symbol+columns key.
- **`ParamPlan`/`ParamMember`**: the command-factory side — member db-types with the Add-mode sizing decisions precomputed, directions, DbString/cancellation/row-count facts, the anonymous-type shape witness (built at parse), the multi-exec element plan and cast. `CommandFactoryState` keys on plan equality; its `systemObject` fallback becomes a plan.
- **structural equality on the source states themselves** — with plain fields but reference equality, the node-level incremental cache still re-ran downstream on every edit; the states now compare by value, and `ModelShapeTests` covers the `SourceState` family and requires equality on nested model types.
- **`InterceptorEnvironment`**: the output step's compilation facts (AllowUnsafe, assembly name, `InterceptsLocationAttribute` availability, the DbCommand special-types sweep, module-level `[CommandFactory<T>]`, the object fallback plan) projected via `Select`, so edits that don't change any of them no longer re-run generation. The analyzer-bridge path builds the same environment.

**Zero Roslyn objects remain in the cached model.** Byte-identical output verified at every increment, two ways: all golden fixtures unchanged (net10/net48), and the Dapper test suite's full generated file (725 call-sites) hashes identical (`f8d3a61f`) before and after the entire rework.