### PR TITLE
Fix the [CommandProperty] field probe: readonly means not assignable

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/AdditionalCommandState.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/AdditionalCommandState.cs
@@ -1,4 +1,4 @@
-using Dapper.CodeAnalysis;
+﻿using Dapper.CodeAnalysis;
 using Dapper.Internal;
 using Microsoft.CodeAnalysis;
 using System;
@@ -56,7 +56,6 @@ internal readonly struct CommandProperty : IEquatable<CommandProperty>
             location is null ? default : new LocationSnapshot(location));
     }
 
-    // note: preserved exactly from the emit-time check it replaces, quirks and all
     private static bool HasPublicSettableInstanceMember(ITypeSymbol type, string name)
     {
         foreach (var member in type.GetMembers())
@@ -64,7 +63,7 @@ internal readonly struct CommandProperty : IEquatable<CommandProperty>
             if (member.IsStatic || member.Name != name || member.DeclaredAccessibility != Accessibility.Public) continue;
             return member.Kind switch
             {
-                SymbolKind.Field when member is IFieldSymbol field => field.IsReadOnly,
+                SymbolKind.Field when member is IFieldSymbol field => !field.IsReadOnly,
                 SymbolKind.Property when member is IPropertySymbol prop => prop.SetMethod is not null,
                 _ => false,
             };

--- a/test/Dapper.AOT.Test/CommandPropertyMemberTests.cs
+++ b/test/Dapper.AOT.Test/CommandPropertyMemberTests.cs
@@ -1,0 +1,43 @@
+using Dapper.AOT.Test.TestCommon;
+using Dapper.CodeAnalysis.Model;
+using Microsoft.CodeAnalysis;
+using System.Linq;
+using Xunit;
+
+namespace Dapper.AOT.Test;
+
+/// <summary>
+/// The [CommandProperty] member probe: a public mutable field is assignable, a readonly
+/// field is not (this was inverted for a long time - it never fired in anger because real
+/// ADO.NET command types expose these knobs as properties).
+/// </summary>
+public class CommandPropertyMemberTests
+{
+    const string Source = """
+        public class SomeCommandType
+        {
+            public int MutableField;
+            public readonly int ReadOnlyField;
+            public int SettableProperty { get; set; }
+            public int GetOnlyProperty { get; }
+            public static int StaticProperty { get; set; }
+        }
+        """;
+
+    static bool MemberExists(string name)
+    {
+        var compilation = RoslynTestHelpers.CreateCompilation(Source, "cmdprop_test", "Input.cs");
+        var type = (INamedTypeSymbol)compilation.GetSymbolsWithName("SomeCommandType").Single();
+        return CommandProperty.Create(type, name, 42, null).MemberExists;
+    }
+
+    [Theory]
+    [InlineData("MutableField", true)]
+    [InlineData("ReadOnlyField", false)]
+    [InlineData("SettableProperty", true)]
+    [InlineData("GetOnlyProperty", false)]
+    [InlineData("StaticProperty", false)]
+    [InlineData("DoesNotExist", false)]
+    public void MemberProbeReflectsAssignability(string name, bool expected)
+        => Assert.Equal(expected, MemberExists(name));
+}


### PR DESCRIPTION
The `[CommandProperty]` member-exists probe returned true for a public **readonly** field and false for a mutable one — inverted. It never fired in anger because real ADO.NET command types expose these knobs (`BindByName`, `InitialLONGFetchSize`) as properties, which were checked correctly; but a `[CommandProperty]` naming a mutable public field was wrongly rejected with DAP033, and naming a readonly one passed validation and then emitted an assignment that cannot compile (CS0191) in the consumer's build.

I kept this out of the capture-model rework deliberately (#187/#188 are byte-identical by contract; this is a behavior change) and stacked it here on #188, where the probe now lives (`CommandProperty.Create`). The new theory covers mutable/readonly fields, settable/get-only properties, static, and missing members; the two field cases fail without the fix. Full suite green (net10.0/net48).