### PR TITLE
DAP051: call out types that are generic only by containment

### DIFF
--- a/docs/rules/DAP051.md
+++ b/docs/rules/DAP051.md
@@ -1,0 +1,46 @@
+# DAP051
+
+Type is only generic by containment
+
+Interceptors cannot handle types that involve generic type parameters (see DAP016), and one
+way to involve them is easy to do *by accident*: declaring an otherwise generic-free type
+inside a generic class. For example:
+
+``` csharp
+public class AnimalTests<TProvider>
+{
+    class Dog // this actually means AnimalTests<TProvider>.Dog
+    {
+        public int Age { get; set; }
+        public string? Name { get; set; }
+    }
+
+    public void GetDogs(DbConnection connection)
+        => connection.Query<Dog>("select Age, Name from Dogs"); // DAP051
+}
+```
+
+Here `Dog` does not *use* `TProvider` at all - but because it is declared inside
+`AnimalTests<TProvider>`, its full identity is `AnimalTests<TProvider>.Dog`, which is a
+different type for every `TProvider`. Generated code cannot name such a type, so Dapper.AOT
+has to leave the call-site on vanilla Dapper (reflection), which will not work under AOT.
+
+**The fix**: if the type does not need the enclosing type parameters, move it out of the
+generic type - to namespace scope, or into a non-generic containing class:
+
+``` csharp
+class Dog // no longer entangled with TProvider
+{
+    public int Age { get; set; }
+    public string? Name { get; set; }
+}
+
+public class AnimalTests<TProvider>
+{
+    public void GetDogs(DbConnection connection)
+        => connection.Query<Dog>("select Age, Name from Dogs"); // works with Dapper.AOT
+}
+```
+
+If the type genuinely needs the enclosing type parameters, this is the same limitation as
+DAP016: generic types cannot currently be used with Dapper.AOT.

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.Diagnostics.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.Diagnostics.cs
@@ -25,6 +25,7 @@ partial class DapperAnalyzer
         DapperAotTupleParameter = LibraryInfo("DAP014", "Tuple-type parameter", "Tuple-type parameters are not currently supported"),
         UntypedParameter = LibraryInfo("DAP015", "Untyped parameter", "The parameter type could not be resolved"),
         GenericTypeParameter = LibraryInfo("DAP016", "Generic type parameter", "Generic type parameters ({0}) are not currently supported"),
+        NestedInGenericType = LibraryWarning("DAP051", "Type is only generic by containment", "Type '{0}' is generic only because it is declared inside generic type '{1}'; if it does not need the enclosing type parameters, move it to non-generic scope"),
         NonPublicType = LibraryInfo("DAP017", "Non-accessible type", "Type '{0}' is not accessible; {1} types are not currently supported"),
         SqlParametersNotDetected = SqlWarning("DAP018", "SQL parameters not detected", "Parameters are being supplied, but no parameters were detected in the command"),
         // unused: DAP019

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -644,7 +644,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                 if (InvolvesGenericTypeParameter(resultType))
                 {
                     flags |= OperationFlags.DoNotGenerate;
-                    reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.GenericTypeParameter, callLocation, resultType!.ToDisplayString()));
+                    ReportGenericTypeParameter(reportDiagnostic, resultType!, callLocation);
                 }
                 else if (resultTuple)
                 {
@@ -724,7 +724,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                 else if (InvolvesGenericTypeParameter(paramType))
                 {
                     flags |= OperationFlags.DoNotGenerate;
-                    reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.GenericTypeParameter, argLocation, paramType!.ToDisplayString()));
+                    ReportGenericTypeParameter(reportDiagnostic, paramType!, argLocation);
                 }
                 else if (IsMissingOrObjectOrDynamic(paramType) || IsDynamicParameters(paramType, out _))
                 {
@@ -758,7 +758,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
                         if (InvolvesGenericTypeParameter(memberType))
                         {
                             flags |= OperationFlags.DoNotGenerate;
-                            reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.GenericTypeParameter, argLocation, memberType.ToDisplayString()));
+                            ReportGenericTypeParameter(reportDiagnostic, memberType, argLocation);
                             break;
                         }
                         if (!IsPublicOrAssemblyLocal(memberType, ctx, out var failingMember))
@@ -898,6 +898,21 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
 
         return cmdProps.IsDefaultOrEmpty && rowCountHint <= 0 && rowCountHintMember is null && batchSize is null && queryColumns.IsDefault
             ? null : new(rowCountHint, rowCountHintMember?.Member?.Name, batchSize, cmdProps, queryColumns);
+    }
+
+    static void ReportGenericTypeParameter(Action<Diagnostic>? reportDiagnostic, ITypeSymbol type, Location? location)
+    {
+        if (reportDiagnostic is null) return;
+        if (IsGenericByContainmentOnly(type, out var container))
+        {
+            // the common accidental shape, with a concrete fix: move the type out
+            reportDiagnostic(Diagnostic.Create(Diagnostics.NestedInGenericType, location,
+                type.ToDisplayString(), container!.ToDisplayString()));
+        }
+        else
+        {
+            reportDiagnostic(Diagnostic.Create(Diagnostics.GenericTypeParameter, location, type.ToDisplayString()));
+        }
     }
 
     static void ValidateParameters(MemberMap? parameters, OperationFlags flags, Action<Diagnostic> onDiagnostic)

--- a/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
+++ b/src/Dapper.AOT.Analyzers/Internal/Inspection.cs
@@ -342,6 +342,41 @@ internal static class Inspection
         return true;
     }
 
+    /// <summary>
+    /// The type itself is generic-free, but it is declared inside a generic type - so at the
+    /// call-site it is an open type purely by containment. This is the common accidental
+    /// shape (a DTO nested inside a generic helper class), and the fix is usually just to
+    /// move the type out; when true, <paramref name="genericContainer"/> is the culprit.
+    /// </summary>
+    public static bool IsGenericByContainmentOnly(ISymbol? symbol, out INamedTypeSymbol? genericContainer)
+    {
+        genericContainer = null;
+        if (symbol is not INamedTypeSymbol named || !InvolvesGenericTypeParameter(named))
+        {
+            return false;
+        }
+        // the type's own arguments must be clean...
+        if (named.Arity != 0)
+        {
+            foreach (var arg in named.TypeArguments)
+            {
+                if (InvolvesGenericTypeParameter(arg)) return false;
+            }
+        }
+        // ...so the involvement comes from a containing type
+        var container = named.ContainingType;
+        while (container is not null)
+        {
+            if (container.Arity != 0)
+            {
+                genericContainer = container;
+                return true;
+            }
+            container = container.ContainingType;
+        }
+        return false;
+    }
+
     public static bool InvolvesGenericTypeParameter(ISymbol? symbol)
     {
         while (symbol is not null)

--- a/test/Dapper.AOT.Test/Verifiers/DAP016.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP016.cs
@@ -47,6 +47,7 @@ public class DAP016 : Verifier<DapperAnalyzer>
         }
         class Poco { public int Id {get;set;} }
         """, DefaultConfig, [
-            Diagnostic(Diagnostics.GenericTypeParameter).WithLocation(0).WithArguments("GenericType<TX>.Nested")]);
+            // note: this shape now gets the more specific DAP051 (nested-in-generic) guidance
+            Diagnostic(Diagnostics.NestedInGenericType).WithLocation(0).WithArguments("GenericType<TX>.Nested", "GenericType<TX>")]);
 
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP051.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP051.cs
@@ -1,0 +1,33 @@
+using Dapper.CodeAnalysis;
+using System.Threading.Tasks;
+using Xunit;
+using static Dapper.CodeAnalysis.DapperAnalyzer;
+
+namespace Dapper.AOT.Test.Verifiers;
+
+public class DAP051 : Verifier<DapperAnalyzer>
+{
+    [Fact] // the accidental shape: a generic-free DTO nested inside a generic class
+    public Task NestedInGenericType() => CSVerifyAsync("""
+        using Dapper;
+        using System.Data.Common;
+
+        [DapperAot]
+        public class AnimalTests<TProvider>
+        {
+            class Dog { public int Age {get;set;} public string? Name {get;set;} }
+
+            void ViaResult(DbConnection conn) => _ = conn.{|#0:Query<Dog>|}("somesql");
+            void ViaParameter(DbConnection conn, Dog args) => conn.Execute("somesql", {|#1:args|});
+            void ViaMember(DbConnection conn, Dog value) => conn.Execute("somesql", {|#2:new { value }|});
+
+            // genuinely generic usage stays DAP016
+            void TrueGeneric<T>(DbConnection conn, T args) => conn.Execute("somesql", {|#3:args|});
+        }
+        """, DefaultConfig, [
+            Diagnostic(Diagnostics.NestedInGenericType).WithLocation(0).WithArguments("AnimalTests<TProvider>.Dog", "AnimalTests<TProvider>"),
+            Diagnostic(Diagnostics.NestedInGenericType).WithLocation(1).WithArguments("AnimalTests<TProvider>.Dog", "AnimalTests<TProvider>"),
+            Diagnostic(Diagnostics.NestedInGenericType).WithLocation(2).WithArguments("AnimalTests<TProvider>.Dog", "AnimalTests<TProvider>"),
+            Diagnostic(Diagnostics.GenericTypeParameter).WithLocation(3).WithArguments("T"),
+    ]);
+}


### PR DESCRIPTION
DAP016 lumps together genuinely-generic usage and an accidental shape that deserves its own story: a generic-free DTO declared inside a generic class, where the type is open purely by containment —

```csharp
public class AnimalTests<TProvider>
{
    class Dog { ... }                       // actually AnimalTests<TProvider>.Dog
    ... connection.Query<Dog>(...) ...      // DAP051
}
```

`Dog` never uses `TProvider`, but `AnimalTests<A>.Dog` and `AnimalTests<B>.Dog` are different types, so generated code cannot name one — and the fix is usually just to move the type out. This shape is the single largest reason the Dapper test suite is not fully intercepted (272 of ~338 skipped call-sites), so it gets: its own id with the culprit container named in the message, **warning** severity (Info is invisible in MSBuild output, which defeats "make it obvious"), and a docs page with the concrete before/after example.

Genuinely generic usage keeps DAP016. Applies at all three check sites (results, parameters, parameter members); new verifier covers all three plus the still-DAP016 case; full suite green (net10.0/net48).