### PR TITLE
typeof(dynamic) is not legal: use object in the tokenizer type test

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperInterceptorGenerator.cs
@@ -874,7 +874,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         }
                         else
                         {
-                            sb.Append("token = type == typeof(").Append(member.NonNullTypeName).Append(") ? ").Append(token)
+                            sb.Append("token = type == typeof(").Append(member.TypeOfName).Append(") ? ").Append(token)
                             .Append(" : ").Append(token + plan.TotalMemberCount).Append(";")
                             .Append(token == 0 ? " // two tokens for right-typed and type-flexible" : "");
                         }
@@ -905,7 +905,7 @@ public sealed partial class DapperInterceptorGenerator : InterceptorGeneratorBas
                         var member = members[i];
                         if (member.IsMapped)
                         {
-                            sb.Append(i).Append(" => type == typeof(").Append(member.NonNullTypeName).Append(") ? ").Append(i)
+                            sb.Append(i).Append(" => type == typeof(").Append(member.TypeOfName).Append(") ? ").Append(i)
                                 .Append(" : ").Append(i + plan.TotalMemberCount).Append(",").NewLine();
                         }
                     }

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/RowPlan.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/Model/RowPlan.cs
@@ -112,7 +112,8 @@ internal readonly struct RowMember : IEquatable<RowMember>
     public string CodeName { get; }
     public string DbName { get; }
     public string TypeName { get; } // emitted (Append) form of the member type
-    public string NonNullTypeName { get; } // MakeNonNullable form, for typeof(...) tests
+    public string NonNullTypeName { get; } // MakeNonNullable form, for GetValue<T> reads
+    public string TypeOfName { get; } // for typeof(...) tests: dynamic becomes object (typeof(dynamic) is not legal C#)
     public string AnnotatedTypeName { get; } // GetTypeName(WithNullableAnnotation(Annotated)), for the null-check cast
     public bool CouldBeNullable { get; }
     public string? ReaderMethod { get; } // e.g. GetInt32; null = GetFieldValue<T>
@@ -125,7 +126,7 @@ internal readonly struct RowMember : IEquatable<RowMember>
     public bool NeedsDefaultBang { get; } // reference type, not annotated: "default!"
 
     private RowMember(bool isMapped, string codeName, string dbName, string typeName, string nonNullTypeName,
-        string annotatedTypeName, bool couldBeNullable, string? readerMethod, int? constructorParameterOrder,
+        string typeOfName, string annotatedTypeName, bool couldBeNullable, string? readerMethod, int? constructorParameterOrder,
         int? factoryMethodParameterOrder, bool isInitOnly, bool isRequired, bool isGettable, bool isSettable,
         bool needsDefaultBang)
     {
@@ -134,6 +135,7 @@ internal readonly struct RowMember : IEquatable<RowMember>
         DbName = dbName;
         TypeName = typeName;
         NonNullTypeName = nonNullTypeName;
+        TypeOfName = typeOfName;
         AnnotatedTypeName = annotatedTypeName;
         CouldBeNullable = couldBeNullable;
         ReaderMethod = readerMethod;
@@ -150,13 +152,15 @@ internal readonly struct RowMember : IEquatable<RowMember>
     {
         if (!member.IsMapped)
         {
-            return new(false, "", "", "", "", "", false, null, null, null, false, false, false, false, false);
+            return new(false, "", "", "", "", "", "", false, null, null, null, false, false, false, false, false);
         }
         var memberType = member.CodeType!;
         member.GetDbType(out var readerMethod);
+        var nonNullTypeName = CodeWriter.GetAppendTypeName(Inspection.MakeNonNullable(memberType));
         return new(true, member.CodeName, member.DbName,
             CodeWriter.GetAppendTypeName(memberType),
-            CodeWriter.GetAppendTypeName(Inspection.MakeNonNullable(memberType)),
+            nonNullTypeName,
+            memberType.TypeKind == TypeKind.Dynamic ? "object" : nonNullTypeName,
             CodeWriter.GetTypeName(memberType.WithNullableAnnotation(NullableAnnotation.Annotated)),
             Inspection.CouldBeNullable(memberType), readerMethod,
             member.ConstructorParameterOrder, member.FactoryMethodParameterOrder,
@@ -169,6 +173,7 @@ internal readonly struct RowMember : IEquatable<RowMember>
         && string.Equals(DbName, other.DbName, StringComparison.Ordinal)
         && string.Equals(TypeName, other.TypeName, StringComparison.Ordinal)
         && string.Equals(NonNullTypeName, other.NonNullTypeName, StringComparison.Ordinal)
+        && string.Equals(TypeOfName, other.TypeOfName, StringComparison.Ordinal)
         && string.Equals(AnnotatedTypeName, other.AnnotatedTypeName, StringComparison.Ordinal)
         && CouldBeNullable == other.CouldBeNullable
         && string.Equals(ReaderMethod, other.ReaderMethod, StringComparison.Ordinal)

--- a/test/Dapper.AOT.Test/Interceptors/DynamicMember.input.cs
+++ b/test/Dapper.AOT.Test/Interceptors/DynamicMember.input.cs
@@ -1,0 +1,20 @@
+using Dapper;
+using System.Data.Common;
+
+[module: DapperAot]
+
+public static class Foo
+{
+    static void SomeCode(DbConnection connection)
+    {
+        // a dynamic-typed member: the tokenizer's type test must use object, since
+        // typeof(dynamic) is not legal C# (and the reader reports object anyway)
+        _ = connection.Query<HazDynamic>("select_sql");
+    }
+
+    public class HazDynamic
+    {
+        public dynamic Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.cs
+++ b/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.cs
@@ -1,0 +1,117 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\DynamicMember.input.cs", 12, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<global::Foo.HazDynamic> Query0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, Buffered, StoredProcedure, BindResultsByName
+            // returns data: global::Foo.HazDynamic
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), DefaultCommandFactory).QueryBuffered(param, RowFactory0.Instance);
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class RowFactory0 : global::Dapper.RowFactory<global::Foo.HazDynamic>
+        {
+            internal static readonly RowFactory0 Instance = new();
+            private RowFactory0() {}
+            public override object? Tokenize(global::System.Data.Common.DbDataReader reader, global::System.Span<int> tokens, int columnOffset)
+            {
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    int token = -1;
+                    var name = reader.GetName(columnOffset);
+                    var type = reader.GetFieldType(columnOffset);
+                    switch (NormalizedHash(name))
+                    {
+                        case 926444256U when NormalizedEquals(name, "id"):
+                            token = type == typeof(object) ? 0 : 2; // two tokens for right-typed and type-flexible
+                            break;
+                        case 2369371622U when NormalizedEquals(name, "name"):
+                            token = type == typeof(string) ? 1 : 3;
+                            break;
+
+                    }
+                    tokens[i] = token;
+                    columnOffset++;
+
+                }
+                return null;
+            }
+            public override global::Foo.HazDynamic Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)
+            {
+                global::Foo.HazDynamic result = new();
+                foreach (var token in tokens)
+                {
+                    switch (token)
+                    {
+                        case 0:
+                            result.Id = reader.IsDBNull(columnOffset) ? (dynamic?)null : reader.GetFieldValue<dynamic>(columnOffset);
+                            break;
+                        case 2:
+                            result.Id = reader.IsDBNull(columnOffset) ? (dynamic?)null : GetValue<dynamic>(reader, columnOffset);
+                            break;
+                        case 1:
+                            result.Name = reader.IsDBNull(columnOffset) ? (string?)null : reader.GetString(columnOffset);
+                            break;
+                        case 3:
+                            result.Name = reader.IsDBNull(columnOffset) ? (string?)null : GetValue<string>(reader, columnOffset);
+                            break;
+
+                    }
+                    columnOffset++;
+
+                }
+                return result;
+
+            }
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.netfx.cs
+++ b/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.netfx.cs
@@ -1,0 +1,117 @@
+#nullable enable
+#pragma warning disable IDE0078 // unnecessary suppression is necessary
+#pragma warning disable CS9270 // SDK-dependent change to interceptors usage
+namespace Dapper.AOT // interceptors must be in a known namespace
+{
+    file static class DapperGeneratedInterceptors
+    {
+        [global::System.Runtime.CompilerServices.InterceptsLocationAttribute("Interceptors\\DynamicMember.input.cs", 12, 24)]
+        internal static global::System.Collections.Generic.IEnumerable<global::Foo.HazDynamic> Query0(this global::System.Data.IDbConnection cnn, string sql, object? param, global::System.Data.IDbTransaction? transaction, bool buffered, int? commandTimeout, global::System.Data.CommandType? commandType)
+        {
+            // Query, TypedResult, Buffered, StoredProcedure, BindResultsByName
+            // returns data: global::Foo.HazDynamic
+            global::System.Diagnostics.Debug.Assert(!string.IsNullOrWhiteSpace(sql));
+            global::System.Diagnostics.Debug.Assert((commandType ?? global::Dapper.DapperAotExtensions.GetCommandType(sql)) == global::System.Data.CommandType.StoredProcedure);
+            global::System.Diagnostics.Debug.Assert(buffered is true);
+            global::System.Diagnostics.Debug.Assert(param is null);
+
+            return global::Dapper.DapperAotExtensions.Command(cnn, transaction, sql, global::System.Data.CommandType.StoredProcedure, commandTimeout.GetValueOrDefault(), DefaultCommandFactory).QueryBuffered(param, RowFactory0.Instance);
+
+        }
+
+        private class CommonCommandFactory<T> : global::Dapper.CommandFactory<T>
+        {
+            public override global::System.Data.Common.DbCommand GetCommand(global::System.Data.Common.DbConnection connection, string sql, global::System.Data.CommandType commandType, T args)
+            {
+                var cmd = base.GetCommand(connection, sql, commandType, args);
+                // apply special per-provider command initialization logic for OracleCommand
+                if (cmd is global::Oracle.ManagedDataAccess.Client.OracleCommand cmd0)
+                {
+                    cmd0.BindByName = true;
+                    cmd0.InitialLONGFetchSize = -1;
+
+                }
+                return cmd;
+            }
+
+        }
+
+        private static readonly CommonCommandFactory<object?> DefaultCommandFactory = new();
+
+        private sealed class RowFactory0 : global::Dapper.RowFactory<global::Foo.HazDynamic>
+        {
+            internal static readonly RowFactory0 Instance = new();
+            private RowFactory0() {}
+            public override object? Tokenize(global::System.Data.Common.DbDataReader reader, global::System.Span<int> tokens, int columnOffset)
+            {
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    int token = -1;
+                    var name = reader.GetName(columnOffset);
+                    var type = reader.GetFieldType(columnOffset);
+                    switch (NormalizedHash(name))
+                    {
+                        case 926444256U when NormalizedEquals(name, "id"):
+                            token = type == typeof(object) ? 0 : 2; // two tokens for right-typed and type-flexible
+                            break;
+                        case 2369371622U when NormalizedEquals(name, "name"):
+                            token = type == typeof(string) ? 1 : 3;
+                            break;
+
+                    }
+                    tokens[i] = token;
+                    columnOffset++;
+
+                }
+                return null;
+            }
+            public override global::Foo.HazDynamic Read(global::System.Data.Common.DbDataReader reader, global::System.ReadOnlySpan<int> tokens, int columnOffset, object? state)
+            {
+                global::Foo.HazDynamic result = new();
+                foreach (var token in tokens)
+                {
+                    switch (token)
+                    {
+                        case 0:
+                            result.Id = reader.IsDBNull(columnOffset) ? (dynamic?)null : reader.GetFieldValue<dynamic>(columnOffset);
+                            break;
+                        case 2:
+                            result.Id = reader.IsDBNull(columnOffset) ? (dynamic?)null : GetValue<dynamic>(reader, columnOffset);
+                            break;
+                        case 1:
+                            result.Name = reader.IsDBNull(columnOffset) ? (string?)null : reader.GetString(columnOffset);
+                            break;
+                        case 3:
+                            result.Name = reader.IsDBNull(columnOffset) ? (string?)null : GetValue<string>(reader, columnOffset);
+                            break;
+
+                    }
+                    columnOffset++;
+
+                }
+                return result;
+
+            }
+
+        }
+
+
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    // this type is needed by the compiler to implement interceptors - it doesn't need to
+    // come from the runtime itself, though
+
+    [global::System.Diagnostics.Conditional("DEBUG")] // not needed post-build, so: evaporate
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]
+    sealed file class InterceptsLocationAttribute : global::System.Attribute
+    {
+        public InterceptsLocationAttribute(string path, int lineNumber, int columnNumber)
+        {
+            _ = path;
+            _ = lineNumber;
+            _ = columnNumber;
+        }
+    }
+}

--- a/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.netfx.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers

--- a/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.txt
+++ b/test/Dapper.AOT.Test/Interceptors/DynamicMember.output.txt
@@ -1,0 +1,4 @@
+Generator produced 1 diagnostics:
+
+Hidden DAP000  L1 C1
+Dapper.AOT handled 1 of 1 enabled call-sites (0 unsupported API, 0 skipped due to diagnostics) using 1 interceptors, 0 commands and 1 readers


### PR DESCRIPTION
A row type with a `dynamic`-typed member emitted `type == typeof(dynamic)` in `Tokenize`, which is not legal C# (CS1962). The reader reports such columns as `object` anyway, so the type test now uses `typeof(object)`; reading (`GetFieldValue<dynamic>`/`GetValue<dynamic>`) is unaffected, since `dynamic` is fine as a type argument.

Found via the Dapper test suite: `ParameterTests` has a DTO with `public dynamic? Id`, which only started generating once the nested-DTO restructure let Dapper.AOT attempt it. New golden fixture (`DynamicMember`) pins the emission; full unit suite green.

Note for the capture-model stack (#188): the equivalent site there is `RowMember.Create`'s `NonNullTypeName` projection — I'll port this when resolving that stack against main.