### PR TITLE
Match vanilla's default CommandBehavior: no SingleResult/SingleRow

### DIFF
--- a/notes/parity.md
+++ b/notes/parity.md
@@ -104,7 +104,7 @@ Two levers change several complexity scores and are worth naming up front:
 | `Settings.CommandTimeout` (global default) | ❓ | med | low | AOT has per-site args + `[CommandProperty]`; needs a global knob |
 | `Settings.InListStringSplitCount` | ❌ | med | low* | *after* list expansion; SQL Server plan-stability win |
 | `Settings.PadListExpansions` | ❌ | low-med | low* | same |
-| `Settings.UseSingleResult/UseSingleRowOptimization` | ❓ | low | low | **PR #196 open**: verification found a real divergence (AOT hardcoded the opt-in flags; swallowed trailing errors, 10x slower async) — now matches vanilla's default |
+| `Settings.UseSingleResult/UseSingleRowOptimization` | ✅ | — | — | verification found a real divergence (AOT hardcoded the opt-in flags; swallowed trailing errors, 10x slower async); now matches vanilla's default — no flags. The runtime knobs stay unread, with the opt-in location noted in code |
 | `Settings.FetchSize` (Oracle) | ⚠️ | low | low | `GlobalFetchSize` exists; verify |
 | `SqlMapper.ConnectionStringComparer` | 🚫? | **zero-ish** | — | exists to partition the runtime identity/cache — a concept AOT doesn't have |
 | `FeatureSupport` (per-provider null-array quirks) | ❓ | low | low | folds into list-expansion helper |

--- a/src/Dapper.AOT/CommandT.Query.cs
+++ b/src/Dapper.AOT/CommandT.Query.cs
@@ -25,7 +25,7 @@ partial struct Command<TArgs>
         SyncQueryState state = default;
         try
         {
-            state.ExecuteReader(GetCommand(args), CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
+            state.ExecuteReader(GetCommand(args), CommandBehavior.SequentialAccess);
 
             List<TRow> results;
             if (state.Reader.Read())
@@ -70,7 +70,7 @@ partial struct Command<TArgs>
         try
         {
             cancellationToken = GetCancellationToken(args, cancellationToken);
-            await state.ExecuteReaderAsync(GetCommand(args), CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, cancellationToken);
+            await state.ExecuteReaderAsync(GetCommand(args), CommandBehavior.SequentialAccess, cancellationToken);
 
             List<TRow> results;
             if (await state.Reader.ReadAsync(cancellationToken))
@@ -110,7 +110,7 @@ partial struct Command<TArgs>
         try
         {
             cancellationToken = GetCancellationToken(args, cancellationToken);
-            await state.ExecuteReaderAsync(GetCommand(args), CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, cancellationToken);
+            await state.ExecuteReaderAsync(GetCommand(args), CommandBehavior.SequentialAccess, cancellationToken);
 
             if (await state.Reader.ReadAsync(cancellationToken))
             {
@@ -140,7 +140,7 @@ partial struct Command<TArgs>
         SyncQueryState state = default;
         try
         {
-            state.ExecuteReader(GetCommand(args), CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
+            state.ExecuteReader(GetCommand(args), CommandBehavior.SequentialAccess);
 
             if (state.Reader.Read())
             {
@@ -163,10 +163,13 @@ partial struct Command<TArgs>
     }
 
     // if we don't care if there's two rows, we can restrict to read one only
+    // note: deliberately *not* SingleResult/SingleRow, matching vanilla Dapper's defaults
+    // (Settings.UseSingleResultOptimization / UseSingleRowOptimization are opt-in there):
+    // both make SqlClient cancel the remainder of the batch on close, silently discarding
+    // trailing errors ("select ...; raiserror(...)"), and the combination measured 10x
+    // slower on the async one-row path; if opt-in knobs are ever wanted, they belong here
     static CommandBehavior SingleFlags(OneRowFlags flags)
-        => (flags & OneRowFlags.ThrowIfMultiple) == 0
-            ? CommandBehavior.SingleResult | CommandBehavior.SequentialAccess | CommandBehavior.SingleRow
-            : CommandBehavior.SingleResult | CommandBehavior.SequentialAccess;
+        => CommandBehavior.SequentialAccess;
 
     private TRow? QueryOneRow<TRow>(
         TArgs args,


### PR DESCRIPTION
The one-row and query paths hardcoded `SingleResult` (plus `SingleRow` for First/FirstOrDefault), where vanilla strips both **by default** — `Settings.UseSingleResultOptimization`/`UseSingleRowOptimization` are opt-in, and the default exists for a reason: with those flags SqlClient cancels the remainder of the batch on close, silently discarding trailing errors.

Found by the Dapper test suite's `QueryFirst_PerformanceAndCorrectness`, then pinned with a side-by-side repro on one connection:

| | vanilla | Dapper.AOT before | after |
| --- | --- | --- | --- |
| `QueryFirst("select *; raiserror(...)")` | throws `SqlException` | **no exception** | throws `SqlException` |
| async `QueryFirst` over 100k rows | fast | **568ms** | 57ms |

(The suite's 500k-row variant burned ~4.5 minutes per provider before.)

Fix: `SequentialAccess` only, i.e. vanilla's effective default. If opt-in optimization knobs are ever wanted, they belong in `SingleFlags` — noted in the comment there. Runtime-library change only; full unit suite green on net10.0/net48, goldens untouched.