### PR TITLE
Clear parameters when tearing down a command

### DIFF
--- a/src/Dapper.AOT/Internal/AsyncCommandState.cs
+++ b/src/Dapper.AOT/Internal/AsyncCommandState.cs
@@ -123,6 +123,8 @@ namespace Dapper.Internal
 
             if (cmd is not null)
             {
+                // match vanilla's teardown: release caller-supplied parameter objects
+                cmd.Parameters.Clear();
                 if (conn is not null && (_flags & FLAG_CLOSE_CONNECTION) != 0)
                 {
                     // need to close the connection and dispose the command
@@ -178,7 +180,12 @@ namespace Dapper.Internal
         {
             var cmd = Command;
             Command = null;
-            cmd?.Dispose();
+            if (cmd is not null)
+            {
+                // match vanilla's teardown: release caller-supplied parameter objects
+                cmd.Parameters.Clear();
+                cmd.Dispose();
+            }
 
             var conn = connection;
             connection = null;

--- a/src/Dapper.AOT/Internal/SyncCommandState.cs
+++ b/src/Dapper.AOT/Internal/SyncCommandState.cs
@@ -62,7 +62,12 @@ namespace Dapper.Internal
         {
             var cmd = Command;
             Command = null;
-            cmd?.Dispose();
+            if (cmd is not null)
+            {
+                // match vanilla's teardown: release caller-supplied parameter objects
+                cmd.Parameters.Clear();
+                cmd.Dispose();
+            }
 
             var conn = connection;
             connection = null;

--- a/src/Dapper.AOT/UnifiedCommand.cs
+++ b/src/Dapper.AOT/UnifiedCommand.cs
@@ -219,7 +219,14 @@ public readonly struct UnifiedCommand
 
     internal void Cleanup()
     {
-        dbCommand?.Dispose();
+        if (dbCommand is not null)
+        {
+            // match vanilla Dapper's teardown: a parameter object the caller supplied
+            // (ICustomQueryParameter, DynamicParameters.Add(DbParameter), etc) must not
+            // stay owned by a dead command's collection, or it cannot be reused
+            dbCommand.Parameters.Clear();
+            dbCommand.Dispose();
+        }
 #if NET6_0_OR_GREATER
         batch?.Dispose();
 #endif


### PR DESCRIPTION
Vanilla Dapper's finally blocks all do `cmd.Parameters.Clear()` before the command is disposed (the "Add-tastic" comments), and it's load-bearing rather than tidy: a parameter object the caller supplied — an `ICustomQueryParameter`'s `DbParameter`, or one added to `DynamicParameters` directly — otherwise stays owned by the dead command's collection, and the next use throws *"The SqlParameter is already contained by another SqlParameterCollection"*. That's exactly what the Dapper test suite's `TestCustomParameterReuse` catches once #198 makes custom parameters work at all.

`UnifiedCommand.Cleanup` now clears before disposing. Recycled commands keep their parameters, as before — recycling doesn't pass through `Cleanup`.