### PR TITLE
DynamicRecord: null (not DBNull) on the dynamic surface, and mutable like DapperRow

### DIFF
--- a/notes/parity.md
+++ b/notes/parity.md
@@ -85,7 +85,7 @@ Two levers change several complexity scores and are worth naming up front:
 | constructor binding, `[ExplicitConstructor]` | ✅ | — | — | plus factory methods (AOT extension) |
 | `required` / init-only members | ✅ | — | — | `RequiredProperties` fixture |
 | fields | ❓ | low | low | verify |
-| `dynamic` rows — behavioral fidelity | ⚠️ | high | med | **PR #200 open**: null (not DBNull) on the dynamic surface, mutation (set/add/remove), missing member is null with the cast throwing — the whole matrix the suite pins |
+| `dynamic` rows — behavioral fidelity | ✅ | — | — | null (not DBNull) on the dynamic and dictionary surfaces, mutation (set/add/remove), missing member is null with the value-type cast throwing from the binder — the matrix the suite pins. The `DbDataRecord` surface keeps its ADO.NET contract |
 | tuple results | ❌ | med | med | DAP013; design already framed by `[BindTupleByName]` |
 | enum results (string→enum case-insens., widening, `ShortEnum`) | ⚠️❓ | high | low-med | Dapper recently changed precedence (prefer type handlers, #2200) — match the *new* behavior |
 | `MatchNamesWithUnderscores` | ❓ | med-high | low | snake_case databases; needs a compile-time equivalent (global option/attr) |

--- a/src/Dapper.AOT/Internal/DynamicRecord.cs
+++ b/src/Dapper.AOT/Internal/DynamicRecord.cs
@@ -80,11 +80,10 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
 
     private object? GetRawValue(string name)
     {
+        // try-get semantics: vanilla's DapperRow returns null for a missing member (a
+        // value-type dynamic cast is then what produces the RuntimeBinderException)
         var index = GetOrdinal(name);
-        if (index < 0) Throw(name);
-        return values[index];
-
-        static void Throw(string name) => throw new KeyNotFoundException($"Member '{name}' not found");
+        return index < 0 ? null : values[index];
     }
 
     private void SetValue(string name, object? value)
@@ -187,7 +186,17 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
     protected override DbDataReader GetDbDataReader(int i) => throw new NotSupportedException();
 
     public override object GetValue(int i) => values[i] ?? DBNull.Value;
-    public override object this[string name] => GetRawValue(name) ?? DBNull.Value;
+    public override object this[string name]
+    {
+        get
+        {
+            var index = GetOrdinal(name);
+            if (index < 0) Throw(name);
+            return values[index] ?? DBNull.Value;
+
+            static void Throw(string name) => throw new KeyNotFoundException($"Member '{name}' not found");
+        }
+    }
     public override object this[int i] => values[i] ?? DBNull.Value;
 
     private T As<T>(int i) => CommandUtils.As<T>(values[i]);

--- a/src/Dapper.AOT/Internal/DynamicRecord.cs
+++ b/src/Dapper.AOT/Internal/DynamicRecord.cs
@@ -42,8 +42,10 @@ internal readonly struct DynamicRecordField
 internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, object?>, IDictionary<string, object?>,
     IDynamicMetaObjectProvider
 {
-    private readonly DynamicRecordField[] fields;
-    private readonly object[] values;
+    // the fields array is shared between every record of the shape (it is the Tokenize
+    // state), so structural mutation (add/remove) must copy-on-write before diverging
+    private DynamicRecordField[] fields;
+    private object?[] values;
     private string[]? namesCopy;
     public DynamicRecord(DynamicRecordField[] fields, DbDataReader source, int columnOffset)
     {
@@ -54,19 +56,73 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
         }
         else
         {
-            values = new object[fields.Length];
-            if (columnOffset == 0 && source.FieldCount == values.Length)
+            var typed = new object[fields.Length];
+            if (columnOffset == 0 && source.FieldCount == typed.Length)
             {
-                source.GetValues(values);
+                source.GetValues(typed);
             }
             else
             {
-                for (int i = 0; i < values.Length; i++)
+                for (int i = 0; i < typed.Length; i++)
                 {
-                    values[i] = source.GetValue(columnOffset++);
+                    typed[i] = source.GetValue(columnOffset++);
                 }
             }
+            values = typed;
+            for (int i = 0; i < values.Length; i++)
+            {
+                // the dictionary and dynamic surfaces hand back null, not DBNull, matching
+                // vanilla Dapper's DapperRow; the DbDataRecord surface restores DBNull
+                if (values[i] is DBNull) values[i] = null;
+            }
         }
+    }
+
+    private object? GetRawValue(string name)
+    {
+        var index = GetOrdinal(name);
+        if (index < 0) Throw(name);
+        return values[index];
+
+        static void Throw(string name) => throw new KeyNotFoundException($"Member '{name}' not found");
+    }
+
+    private void SetValue(string name, object? value)
+    {
+        var i = GetOrdinal(name);
+        if (i >= 0)
+        {
+            values[i] = value;
+            return;
+        }
+        // grow; the fields array may still be the shared per-shape one, so always copy
+        var len = fields.Length;
+        var newFields = new DynamicRecordField[len + 1];
+        Array.Copy(fields, newFields, len);
+        newFields[len] = new DynamicRecordField(name, value?.GetType() ?? typeof(object), "");
+        var newValues = new object?[len + 1];
+        Array.Copy(values, newValues, len);
+        newValues[len] = value;
+        fields = newFields;
+        values = newValues;
+        namesCopy = null;
+    }
+
+    private bool Remove(string name)
+    {
+        var i = GetOrdinal(name);
+        if (i < 0) return false;
+        var len = fields.Length;
+        var newFields = new DynamicRecordField[len - 1];
+        Array.Copy(fields, newFields, i);
+        Array.Copy(fields, i + 1, newFields, i, len - i - 1);
+        var newValues = new object?[len - 1];
+        Array.Copy(values, newValues, i);
+        Array.Copy(values, i + 1, newValues, i, len - i - 1);
+        fields = newFields;
+        values = newValues;
+        namesCopy = null;
+        return true;
     }
     public override int GetOrdinal(string name)
     {
@@ -92,7 +148,7 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
 
     public IEnumerable<string> Keys => GetSafeNamesCopy();
 
-    public IEnumerable<object> Values => values;
+    public IEnumerable<object?> Values => values;
 
     public int Count => FieldCount;
 
@@ -116,31 +172,23 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
 
     ICollection<object?> IDictionary<string, object?>.Values => values;
 
-    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => true;
+    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => false;
 
     object? IDictionary<string, object?>.this[string key]
     {
-        get => this[key];
-        set => throw new NotSupportedException();
+        get => GetRawValue(key);
+        set => SetValue(key, value); // set-or-add, matching vanilla's DapperRow
     }
+
+    object? IReadOnlyDictionary<string, object?>.this[string key] => GetRawValue(key);
 
     public override string GetName(int i) => fields[i].Name;
     public override Type GetFieldType(int i) => fields[i].Type;
     protected override DbDataReader GetDbDataReader(int i) => throw new NotSupportedException();
 
-    public override object GetValue(int i) => values[i];
-    public override object this[string name]
-    {
-        get
-        {
-            var index = GetOrdinal(name);
-            if (index < 0) Throw(name);
-            return values[index];
-
-            static void Throw(string name) => throw new KeyNotFoundException($"Member '{name}' not found");
-        }
-    }
-    public override object this[int i] => values[i];
+    public override object GetValue(int i) => values[i] ?? DBNull.Value;
+    public override object this[string name] => GetRawValue(name) ?? DBNull.Value;
+    public override object this[int i] => values[i] ?? DBNull.Value;
 
     private T As<T>(int i) => CommandUtils.As<T>(values[i]);
     public override bool GetBoolean(int i) => As<bool>(i);
@@ -171,7 +219,7 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
     public override long GetBytes(int i, long dataIndex, byte[]? buffer, int bufferIndex, int length)
     {
         if (buffer is null) return 0;
-        byte[] blob = (byte[])values[i];
+        byte[] blob = (byte[])GetValue(i);
         Buffer.BlockCopy(blob, CheckOffsetAndComputeLength(blob.Length, dataIndex, ref length), buffer, bufferIndex, length);
         return length;
     }
@@ -184,7 +232,7 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
         }
         else
         {
-            char[] clob = (char[])values[i];
+            char[] clob = (char[])GetValue(i);
             Array.Copy(clob, CheckOffsetAndComputeLength(clob.Length, dataIndex, ref length), buffer, bufferIndex, length);
         }
         return length;
@@ -214,13 +262,18 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    void IDictionary<string, object?>.Add(string key, object? value) => throw new NotSupportedException();
+    void IDictionary<string, object?>.Add(string key, object? value) => SetValue(key, value);
 
-    bool IDictionary<string, object?>.Remove(string key) => throw new NotSupportedException();
+    bool IDictionary<string, object?>.Remove(string key) => Remove(key);
 
-    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => throw new NotSupportedException();
+    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => SetValue(item.Key, item.Value);
 
-    void ICollection<KeyValuePair<string, object?>>.Clear() => throw new NotSupportedException();
+    void ICollection<KeyValuePair<string, object?>>.Clear()
+    {
+        fields = Array.Empty<DynamicRecordField>();
+        values = Array.Empty<object>();
+        namesCopy = null;
+    }
 
     bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item)
         => TryGetValue(item.Key, out var value) && Equals(value, item.Value);
@@ -233,19 +286,23 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
         }
     }
 
-    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => throw new NotSupportedException();
+    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item)
+        => TryGetValue(item.Key, out var value) && Equals(value, item.Value) && Remove(item.Key);
 
     DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
         => new DynamicRecordMetaObject(parameter, BindingRestrictions.Empty, this);
 
     private sealed class DynamicRecordMetaObject : DynamicMetaObject
     {
-        private static readonly MethodInfo getValueMethod;
+        private static readonly MethodInfo getValueMethod, setValueMethod;
         static DynamicRecordMetaObject()
         {
-            IReadOnlyDictionary<string, object> tmp = new Dictionary<string, object> { { "", "" } };
-            _ = tmp[""]; // to ensure the indexer is not trimmed away
+            IDictionary<string, object> tmp = new Dictionary<string, object> { { "", "" } };
+            _ = tmp[""]; // to ensure the indexers are not trimmed away
+            tmp[""] = "";
             getValueMethod = typeof(IReadOnlyDictionary<string, object>).GetProperty("Item")?.GetGetMethod()
+                ?? throw new InvalidOperationException("Unable to resolve indexer");
+            setValueMethod = typeof(IDictionary<string, object>).GetProperty("Item")?.GetSetMethod()
                 ?? throw new InvalidOperationException("Unable to resolve indexer");
         }
 
@@ -283,7 +340,19 @@ internal sealed class DynamicRecord : DbDataRecord, IReadOnlyDictionary<string, 
         }
 
         public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
-            => throw new NotSupportedException("Dynamic records are considered read-only currently");
+        {
+            // the binding must *produce* the assigned value (assignment is an expression);
+            // the indexer's set returns void, so wrap it in a block yielding the value
+            var valueArg = Expression.Convert(value.Expression, typeof(object));
+            var call = Expression.Call(
+                Expression.Convert(Expression, LimitType),
+                setValueMethod,
+                Expression.Constant(binder.Name),
+                valueArg);
+            return new DynamicMetaObject(
+                Expression.Block(typeof(object), call, valueArg),
+                BindingRestrictions.GetTypeRestriction(Expression, LimitType));
+        }
 
         // Needed for Visual basic dynamic support
         public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)

--- a/test/Dapper.AOT.Test/Integration/DynamicTests.cs
+++ b/test/Dapper.AOT.Test/Integration/DynamicTests.cs
@@ -21,7 +21,18 @@ public class DynamicTests : IDisposable
         Assert.Equal("Wilma", (string)wilma.Name);
         Assert.True((int)wilma.Id > 0);
         Assert.Throws<KeyNotFoundException>(() => _ = wilma.NotExist);
-        Assert.Throws<NotSupportedException>(() => wilma.Name = "abc");
+
+        // dynamic records are mutable, like vanilla Dapper's DapperRow: an existing
+        // member can be replaced, and a new member added
+        wilma.Name = "abc";
+        Assert.Equal("abc", (string)wilma.Name);
+        wilma.NotExist = 123;
+        Assert.Equal(123, (int)wilma.NotExist);
+
+        IDictionary<string, object?> lookup = wilma;
+        Assert.True(lookup.Remove("NotExist"));
+        Assert.False(lookup.Remove("NotExist"));
+        Assert.Throws<KeyNotFoundException>(() => _ = wilma.NotExist);
     }
 }
 

--- a/test/Dapper.AOT.Test/Integration/DynamicTests.cs
+++ b/test/Dapper.AOT.Test/Integration/DynamicTests.cs
@@ -20,10 +20,13 @@ public class DynamicTests : IDisposable
         Assert.NotNull(wilma);
         Assert.Equal("Wilma", (string)wilma.Name);
         Assert.True((int)wilma.Id > 0);
-        Assert.Throws<KeyNotFoundException>(() => _ = wilma.NotExist);
+        // a missing member is null, like vanilla Dapper's DapperRow; casting that
+        // null to a value type is what throws (from the binder, not from us)
+        Assert.Null((object?)wilma.NotExist);
+        Assert.Throws<Microsoft.CSharp.RuntimeBinder.RuntimeBinderException>(() => _ = (int)wilma.NotExist);
 
-        // dynamic records are mutable, like vanilla Dapper's DapperRow: an existing
-        // member can be replaced, and a new member added
+        // dynamic records are mutable, like vanilla's DapperRow: an existing member
+        // can be replaced, and a new member added and removed
         wilma.Name = "abc";
         Assert.Equal("abc", (string)wilma.Name);
         wilma.NotExist = 123;
@@ -32,7 +35,7 @@ public class DynamicTests : IDisposable
         IDictionary<string, object?> lookup = wilma;
         Assert.True(lookup.Remove("NotExist"));
         Assert.False(lookup.Remove("NotExist"));
-        Assert.Throws<KeyNotFoundException>(() => _ = wilma.NotExist);
+        Assert.Null((object?)wilma.NotExist);
     }
 }
 


### PR DESCRIPTION
Two fidelity gaps against vanilla's `DapperRow`, both caught by running the Dapper test suite over the AOT harness:

- **A null column came back as `DBNull`** from dynamic member access and the dictionary surface, where vanilla hands back null — `(int?)row.A` worked on vanilla and threw `RuntimeBinderException` here (`TestExpandWithNullableFields`, and the async dynamic first/single tests). Values are normalized once at construction; the `DbDataRecord` surface restores `DBNull` (`GetValue`/indexers keep the ADO.NET contract), and `IsDBNull` already accepted both.
- **Dynamic records refused mutation** (`BindSetMember` threw "read-only currently"), where `DapperRow` supports member set, add and remove (`SetDynamicProperty_*`, `TestDynamicMutation`). `BindSetMember` now routes to a set-or-add — yielding the assigned value, which the DLR requires of an assignment expression — and the `IDictionary` surface supports `Add`/`Remove`/`Clear`. The fields array is shared per shape (it's the `Tokenize` state), so structural mutation copies before diverging.

The integration test that pinned the read-only behaviour now pins the mutable behaviour instead. Against the harness this clears `TestExpandWithNullableFields`, the three `SetDynamicProperty_*` tests, `TestDynamicMutation`, and the two async dynamic first/single tests, on both SqlClient providers.