### PR TITLE
Don't report DAP018 when the only parameters are non-SQL members

### DIFF
--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -1159,7 +1159,8 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
         if (byDbName is null)
         {
             // nothing found
-            if (flags.HasAll(OperationFlags.HasParameters | OperationFlags.Text))
+            if (flags.HasAll(OperationFlags.HasParameters | OperationFlags.Text)
+                && !NoSqlParametersSupplied(map))
             {
                 // has args, and is command-text
                 reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.SqlParametersNotDetected, map?.Location));
@@ -1192,4 +1193,9 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
         return builder.ToImmutable();
 
     }
+
+    // members such as cancellation tokens are consumed by Dapper itself; they are never sent as SQL parameters
+    static bool NoSqlParametersSupplied(MemberMap? map)
+        => map is { IsUnknownParameters: false, Members.IsDefaultOrEmpty: false }
+        && map.Members.All(static member => member.Kind != ElementMemberKind.None);
 }

--- a/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
+++ b/src/Dapper.AOT.Analyzers/CodeAnalysis/DapperAnalyzer.cs
@@ -1160,7 +1160,7 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
         {
             // nothing found
             if (flags.HasAll(OperationFlags.HasParameters | OperationFlags.Text)
-                && !NoSqlParametersSupplied(map))
+                && SuppliesSqlParameters(map))
             {
                 // has args, and is command-text
                 reportDiagnostic?.Invoke(Diagnostic.Create(Diagnostics.SqlParametersNotDetected, map?.Location));
@@ -1194,8 +1194,12 @@ public sealed partial class DapperAnalyzer : DiagnosticAnalyzer
 
     }
 
-    // members such as cancellation tokens are consumed by Dapper itself; they are never sent as SQL parameters
-    static bool NoSqlParametersSupplied(MemberMap? map)
-        => map is { IsUnknownParameters: false, Members.IsDefaultOrEmpty: false }
-        && map.Members.All(static member => member.Kind != ElementMemberKind.None);
+    // members such as cancellation tokens and row-counts are consumed by Dapper itself and are
+    // never sent as SQL parameters; only report "no parameters detected" when the args include
+    // at least one member that would actually bind (unknown/dynamic bags: assume they would)
+    static bool SuppliesSqlParameters(MemberMap? map)
+        => map is null
+        || map.IsUnknownParameters
+        || map.Members.IsDefaultOrEmpty
+        || map.Members.Any(static member => member.Kind == ElementMemberKind.None);
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP018.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP018.cs
@@ -75,4 +75,42 @@ public class DAP018(ITestOutputHelper log) : Verifier<DapperAnalyzer>(log)
             }
         }
         """", DefaultConfig, []);
+
+    [Fact]
+    public Task NoFalsePositive_Issue169_CancellationTokenOnly() => CSVerifyAsync(
+        // https://github.com/DapperLib/DapperAOT/issues/169
+        """"
+        using Dapper;
+        using Microsoft.Data.SqlClient;
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        [DapperAot]
+        public static class MyType
+        {
+            public static Task<int> Count(SqlConnection conn, CancellationToken cancellationToken)
+                => conn.QuerySingleAsync<int>(
+                    """select count(*) from CAD.TBL_APLICACAO""",
+                    new { cancellationToken });
+        }
+        """", DefaultConfig, []);
+
+    [Fact]
+    public Task NoFalsePositive_Issue169_CancellationTokenPlusRealParameter() => CSVerifyAsync(
+        // https://github.com/DapperLib/DapperAOT/issues/169
+        """"
+        using Dapper;
+        using Microsoft.Data.SqlClient;
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        [DapperAot]
+        public static class MyType
+        {
+            public static Task<int> Count(SqlConnection conn, int cod, CancellationToken cancellationToken)
+                => conn.QuerySingleAsync<int>(
+                    """select count(*) from CAD.TBL_APLICACAO APP where (APP.APP_COD = @APP_COD)""",
+                    new { APP_COD = cod, cancellationToken });
+        }
+        """", DefaultConfig, []);
 }

--- a/test/Dapper.AOT.Test/Verifiers/DAP018.cs
+++ b/test/Dapper.AOT.Test/Verifiers/DAP018.cs
@@ -95,6 +95,25 @@ public class DAP018(ITestOutputHelper log) : Verifier<DapperAnalyzer>(log)
         }
         """", DefaultConfig, []);
 
+    [Fact] // the boundary the fix must not cross: a member that *would* bind, alongside the
+    // token, with SQL that has no detected parameters - the warning still stands
+    public Task StillWarns_Issue169_RealParameterAlongsideCancellationToken() => CSVerifyAsync(
+        """"
+        using Dapper;
+        using Microsoft.Data.SqlClient;
+        using System.Threading;
+        using System.Threading.Tasks;
+
+        [DapperAot]
+        public static class MyType
+        {
+            public static Task<int> Count(SqlConnection conn, int cod, CancellationToken cancellationToken)
+                => conn.QuerySingleAsync<int>(
+                    """select count(*) from CAD.TBL_APLICACAO""",
+                    {|#0:new { APP_COD = cod, cancellationToken }|});
+        }
+        """", DefaultConfig, [Diagnostic(Diagnostics.SqlParametersNotDetected).WithLocation(0)]);
+
     [Fact]
     public Task NoFalsePositive_Issue169_CancellationTokenPlusRealParameter() => CSVerifyAsync(
         // https://github.com/DapperLib/DapperAOT/issues/169


### PR DESCRIPTION
A parameter object holding nothing but a CancellationToken (or a [RowCount] member) is skipped when building the parameter list, so byDbName ends up null and we report "parameters are being supplied, but no parameters were detected" - even though nothing was actually being supplied to SQL.

Fixes #169 