### PR TITLE
CommandUtils.As: accept a DateOnly source (Npgsql 10 'date' columns)

### DIFF
--- a/src/Dapper.AOT/Internal/CommandUtils.cs
+++ b/src/Dapper.AOT/Internal/CommandUtils.cs
@@ -157,11 +157,26 @@ internal static class CommandUtils
             }
             else if (typeof(T) == typeof(DateTime))
             {
+#if NET6_0_OR_GREATER
+                // Npgsql 10 hands back DateOnly for "date" columns; not IConvertible
+                if (value is DateOnly dateOnlySource)
+                {
+                    DateTime fromDateOnly = dateOnlySource.ToDateTime(TimeOnly.MinValue);
+                    return Unsafe.As<DateTime, T>(ref fromDateOnly);
+                }
+#endif
                 DateTime t = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
                 return Unsafe.As<DateTime, T>(ref t);
             }
             else if (typeof(T) == typeof(DateTime?))
             {
+#if NET6_0_OR_GREATER
+                if (value is DateOnly dateOnlySource)
+                {
+                    DateTime? fromDateOnly = dateOnlySource.ToDateTime(TimeOnly.MinValue);
+                    return Unsafe.As<DateTime?, T>(ref fromDateOnly);
+                }
+#endif
                 DateTime? t = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
                 return Unsafe.As<DateTime?, T>(ref t);
             }
@@ -187,6 +202,12 @@ internal static class CommandUtils
                     var fromSpan = TimeOnly.FromTimeSpan(timeSpan);
                     return Unsafe.As<TimeOnly, T>(ref fromSpan);
                 }
+                if (value is DateOnly)
+                {
+                    // a date has no time component; same answer a zero-time DateTime gives
+                    TimeOnly zero = default;
+                    return Unsafe.As<TimeOnly, T>(ref zero);
+                }
 
                 DateTime t = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
                 var timeOnly = TimeOnly.FromDateTime(t);
@@ -198,6 +219,11 @@ internal static class CommandUtils
                 {
                     var fromSpan = TimeOnly.FromTimeSpan(timeSpan);
                     return Unsafe.As<TimeOnly, T>(ref fromSpan);
+                }
+                if (value is DateOnly)
+                {
+                    TimeOnly? zero = default(TimeOnly);
+                    return Unsafe.As<TimeOnly?, T>(ref zero);
                 }
 
                 DateTime? t = Convert.ToDateTime(value, CultureInfo.InvariantCulture);

--- a/test/Dapper.AOT.Test/CommandUtilsDateOnlyTests.cs
+++ b/test/Dapper.AOT.Test/CommandUtilsDateOnlyTests.cs
@@ -1,0 +1,40 @@
+#if NET6_0_OR_GREATER
+using System;
+using Dapper.Internal;
+using Xunit;
+
+namespace Dapper.AOT.Test
+{
+    // Npgsql 10 hands back DateOnly (not DateTime) for "date" columns; these are the
+    // docker-free half of DateOnlyTimeOnlyPostgreSqlTests, so the coverage does not
+    // depend on a live container (see #202)
+    public class CommandUtilsDateOnlyTests
+    {
+        private static readonly object BoxedDateOnly = new DateOnly(2021, 1, 2);
+
+        [Fact]
+        public void As_DateOnlyToDateTime()
+            => Assert.Equal(new DateTime(2021, 1, 2), CommandUtils.As<DateTime>(BoxedDateOnly));
+
+        [Fact]
+        public void As_DateOnlyToNullableDateTime()
+            => Assert.Equal(new DateTime(2021, 1, 2), CommandUtils.As<DateTime?>(BoxedDateOnly));
+
+        [Fact] // a date has no time component; same answer a zero-time DateTime gives
+        public void As_DateOnlyToTimeOnly()
+            => Assert.Equal(default, CommandUtils.As<TimeOnly>(BoxedDateOnly));
+
+        [Fact]
+        public void As_DateOnlyToNullableTimeOnly()
+            => Assert.Equal(default(TimeOnly), CommandUtils.As<TimeOnly?>(BoxedDateOnly));
+
+        [Fact] // pass-through, unchanged
+        public void As_DateOnlyToDateOnly()
+            => Assert.Equal(new DateOnly(2021, 1, 2), CommandUtils.As<DateOnly>(BoxedDateOnly));
+
+        [Fact] // the pre-Npgsql-10 shape, unchanged
+        public void As_DateTimeToDateOnly()
+            => Assert.Equal(new DateOnly(2021, 1, 2), CommandUtils.As<DateOnly>((object)new DateTime(2021, 1, 2)));
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #202.

Npgsql 10 changed `reader.GetValue()` for a `date` column to return `DateOnly` rather than `DateTime`; `DateOnly` doesn't implement `IConvertible`, so `As<DateTime[?]>`'s fallback through `Convert.ToDateTime` threw `InvalidCastException`. Bisected empirically: the DateOnlyTimeOnly Postgres tests pass on Npgsql 9.0.2 and fail on 10.0.2 (which arrived with #174) — unseen until now because the Postgres integration tests need local Docker.

- `As<DateTime[?]>` from a `DateOnly` converts via `ToDateTime(TimeOnly.MinValue)`
- `As<TimeOnly[?]>` from a `DateOnly` answers default — the same answer a zero-time `DateTime` gives, which is the contract the integration test already documents
- new docker-free unit tests cover the matrix directly, so the coverage no longer depends on a live container

With this, the full unit suite is green on all three TFMs locally (Docker up): 466/466 net10, 466/466 net8, 458/458 net48.