### PR TITLE
Obsolete the never-implemented type-handler pair as a warning, not an error

### DIFF
--- a/src/Dapper.AOT/TypeHandlerT.cs
+++ b/src/Dapper.AOT/TypeHandlerT.cs
@@ -11,7 +11,7 @@ namespace Dapper;
 /// </summary>
 [ImmutableObject(true)]
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method, AllowMultiple = true)]
-[Obsolete("This registration was never implemented: nothing in the analyzer or generator has ever read it, so it has always been a no-op. Use the non-generic [TypeHandler(typeof(TValue), typeof(THandler))] with a handler implementing IDbValueHandler<TValue>.", error: true)]
+[Obsolete("This registration was never implemented: nothing in the analyzer or generator has ever read it, so it has always been a no-op. Use the non-generic [TypeHandler(typeof(TValue), typeof(THandler))] with a handler implementing IDbValueHandler<TValue>.", error: false)]
 public sealed class TypeHandlerAttribute<TValue, TTypeHandler> : Attribute
     where TTypeHandler : TypeHandler<TValue>, new()
 {}
@@ -19,7 +19,7 @@ public sealed class TypeHandlerAttribute<TValue, TTypeHandler> : Attribute
 /// <summary>
 /// Process a parameter value of type <typeparamref name="T"/>
 /// </summary>
-[Obsolete("This handler shape was never implemented: it exists only as the constraint of the obsolete generic [TypeHandler<,>] attribute, which was never read. Use IDbValueHandler<T> (or the DbValueHandler<T> base class), registered with [TypeHandler(typeof(T), typeof(THandler))].", error: true)]
+[Obsolete("This handler shape was never implemented: it exists only as the constraint of the obsolete generic [TypeHandler<,>] attribute, which was never read. Use IDbValueHandler<T> (or the DbValueHandler<T> base class), registered with [TypeHandler(typeof(T), typeof(THandler))].", error: false)]
 public abstract class TypeHandler<T>
 {
     /// <summary>


### PR DESCRIPTION
`TypeHandlerAttribute<TValue, THandler>` and `TypeHandler<T>` were obsoleted as errors in #208. Softening to warnings for the first release that carries the replacement.

Nothing depends on their *behaviour* — they have always been no-ops — but code that names them compiles today, and per the discussion on #173 people did write them. An error turns an upgrade into a build break; a warning still names the replacement (`[TypeHandler(typeof(V), typeof(H))]` + `IDbValueHandler<T>`) and gives people a release to move before it hardens.

One-word change, plus the message text. Suite green (366 net8.0), solution builds clean.