### PR TITLE
Bump the pinned Dapper to 2.1.79

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="FastMember" Version="1.5.0" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="Dapper.AOT" Version="1.0.48" />
-    <PackageVersion Include="Dapper.StrongName" Version="2.1.72" />
+    <PackageVersion Include="Dapper.StrongName" Version="2.1.79" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />

--- a/notes/harness-baseline.md
+++ b/notes/harness-baseline.md
@@ -265,7 +265,9 @@ Parked items unchanged: modern interceptor syntax (soft-target rule), announced 
 (DAP015 x30 object-typed), multi-map / GridReader / ExecuteReader API gaps, the "has no
 meaning" APIs warning. When a Dapper release ships #2225/#2228: bump both Dapper and
 Dapper.StrongName, add the DAP052 positive twin and defer-emit golden (the down-level
-verifier is already pinned to 2.1.72 and survives the bump).
+verifier is already pinned to 2.1.72 and survives the bump). Note the 2026-09-11 bump to
+2.1.79 was *not* that release - #2225/#2228 landed after 2.1.79 shipped, so those items
+are still waiting.
 
 ## Round 11: dynamic-record fidelity (PR #200) - 672/793
 

--- a/notes/state-of-play.md
+++ b/notes/state-of-play.md
@@ -130,7 +130,10 @@ tidying one.
 - **External PRs #117 and #162** were the prior art for the static tier; **both are now closed**,
   superseded by #208. Their instance registry and interceptor goldens were the parts worth
   keeping - triage write-ups exist outside this repo.
-- **Dapper #2225 and #2228 are merged but unreleased** (latest release is still 2.1.79, from
-  May). DapperAOT pins 2.1.72. When a release ships: bump Dapper and Dapper.StrongName, add the
-  DAP052 positive twin and the defer-emit golden, and take the `TestUnexpectedDataMessage`
-  parity that was deferred to that bump.
+- **Dapper #2225 and #2228 are merged but unreleased.** Both landed 2026-08-20; the latest
+  release is still 2.1.79, from May, so no tag contains them. DapperAOT now pins **2.1.79**
+  (bumped 2026-09-11, hygiene only - it changed nothing and unlocks nothing). When a release
+  ships *with those two*: bump again, add the DAP052 positive twin and the defer-emit golden,
+  and take the `TestUnexpectedDataMessage` parity that was deferred to that bump. The DAP052
+  verifier pins 2.1.72 itself (`DAP052.DapperWithoutTheApi`) and is unaffected by either bump -
+  that is deliberate, so it keeps guarding the probe-and-refuse path.


### PR DESCRIPTION
The pin sat at **2.1.72** while **2.1.79** has been out since May, so the analyzer, the generator and the surface report were all being checked against a Dapper two releases behind what consumers actually have.

**Nothing moved.** Solution builds clean; net8.0 and net10.0 are both **377/377**; `ApiSurface.expected.txt` is **unchanged** — which is the interesting part, since that file is compared on every test run precisely so an overload added upstream fails the build rather than quietly aging the parity notes. Two Dapper releases added none.

## This is not the bump the notes are waiting for

Worth being explicit, because the notes have had a "when a release ships" item parked for a while: Dapper **#2225** (`DynamicParameters.AddParameters(IDbCommand)`) and **#2228** (DateOnly/TimeOnly) landed **2026-08-20**, *after* 2.1.79 shipped on 2026-05-16 — no tag contains them. So this bump unlocks nothing, and the DAP052 positive twin, the defer-emit golden and the deferred `TestUnexpectedDataMessage` parity all still wait on a future release. Both `state-of-play.md` and `harness-baseline.md` now say that, rather than leaving the next person to rediscover it.

`DAP052.DapperWithoutTheApi` keeps its own `2.1.72` pin deliberately — that test guards the probe-and-refuse path and is meant to be independent of the project-wide reference, exactly so bumps like this one don't silently disarm it.