### PR TITLE
CI: actually test the net48 leg

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Test .NET 10
         run: dotnet test Build.csproj --no-build --verbosity normal -c Release -f net10.0 --filter FullyQualifiedName!~Integration
 
+      # the job already builds net48, but the *.output.netfx.* interceptor goldens are only
+      # compared at test time - so without this, a netfx golden can be wrong and CI stays green
+      - name: Test .NET Framework 4.8
+        run: dotnet test Build.csproj --no-build --verbosity normal -c Release -f net48 --filter FullyQualifiedName!~Integration
+
       - name: Pack
         if: ${{ success() && !github.base_ref }}
         run: dotnet pack src/Dapper.AOT/Dapper.AOT.csproj --no-build --verbosity normal -c Release


### PR DESCRIPTION
The job already runs on `windows-latest` and **builds** net48, so a compile break there would be caught. But the only test steps are net8.0 and net10.0:

```yaml
- name: Test .NET 8     → dotnet test ... -f net8.0
- name: Test .NET 10    → dotnet test ... -f net10.0
```

That gap matters for one specific reason: the `*.output.netfx.*` interceptor goldens are compared at **test** time, not build time. So a netfx golden can be wrong while CI stays green — which is exactly the state `main` is in right now. #214, #216 and #220 all touched those files, and none of them could be exercised on Linux; the netfx goldens went in on reasoning rather than on a green run.

One more step, same job, same image, same `!~Integration` filter.

**This PR's own CI run is the verification** — if the netfx goldens from those three PRs are right, it goes green and the gap is closed permanently. If they are wrong, we find out here rather than after shipping 1.1.0, which is the entire point.