### PR TITLE
Target 1.1.0, fix the release-tag pattern, and report the version in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore Build.csproj
 
-      - name: Purge
-        run: del src/Dapper.*/bin/Release/Dapper.*.nupkg
-
       - name: Build
         run: dotnet build Build.csproj --no-restore -c Release
 
@@ -56,13 +53,3 @@ jobs:
       # compared at test time - so without this, a netfx golden can be wrong and CI stays green
       - name: Test .NET Framework 4.8
         run: dotnet test Build.csproj --no-build --verbosity normal -c Release -f net48 --filter FullyQualifiedName!~Integration
-
-      - name: Pack
-        if: ${{ success() && !github.base_ref }}
-        run: dotnet pack src/Dapper.AOT/Dapper.AOT.csproj --no-build --verbosity normal -c Release
-
-      - name: Push to MyGet
-        if: ${{ success() && !github.base_ref }}
-        run: dotnet nuget push src/Dapper.*/bin/Release/Dapper.*.nupkg --source https://www.myget.org/F/dapper/api/v2/package --api-key "$env:MYGETAPIKEY"
-        env:
-          MYGETAPIKEY: ${{ secrets.MYGETAPIKEY }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           setAllVars: true
 
+      # deliberately before restore/build, so the version is legible even when a later step
+      # fails. Cutting a release means tagging with exactly what this prints
+      - name: Report computed version
+        run: |
+          $version = nbgv get-version --variable NuGetPackageVersion
+          "### Computed package version: ``$version``" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "Computed package version: $version"
+
       - name: Restore dependencies
         run: dotnet restore Build.csproj
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,12 +30,20 @@ jobs:
           setAllVars: true
 
       # deliberately before restore/build, so the version is legible even when a later step
-      # fails. Cutting a release means tagging with exactly what this prints
+      # fails. Cutting a release means tagging with exactly what a *main* run prints - a PR
+      # run builds refs/pull/N/merge, whose height includes the branch commits and the merge,
+      # so its number is not the one that will ship
       - name: Report computed version
         run: |
           $version = nbgv get-version --variable NuGetPackageVersion
-          "### Computed package version: ``$version``" >> $env:GITHUB_STEP_SUMMARY
-          Write-Output "Computed package version: $version"
+          if ($env:GITHUB_REF -eq 'refs/heads/main') {
+            "### Computed package version: ``$version``" >> $env:GITHUB_STEP_SUMMARY
+            "Tag the release with exactly this." >> $env:GITHUB_STEP_SUMMARY
+          } else {
+            "### Computed package version: ``$version``" >> $env:GITHUB_STEP_SUMMARY
+            "_This is a ``$env:GITHUB_REF`` build - **not** the version that would ship. Read the release version off a main run._" >> $env:GITHUB_STEP_SUMMARY
+          }
+          Write-Output "Computed package version: $version (ref: $env:GITHUB_REF)"
 
       - name: Restore dependencies
         run: dotnet restore Build.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+# Publishes Dapper.AOT and Dapper.Advisor to nuget.org when a GitHub Release is published.
+#
+# Auth is NuGet Trusted Publishing (OIDC): no long-lived API key is stored anywhere.
+# One-time setup on nuget.org, for *each* package: username menu -> Trusted Publishing ->
+# add a policy with
+#   Repository Owner: DapperLib / Repository: DapperAOT / Workflow File: release.yml
+#   Environment: release
+# plus a NUGET_USER repository secret holding the nuget.org profile name to publish as,
+# and a GitHub environment named "release".
+#
+# Versioning note: Nerdbank.GitVersioning computes the version from version.json plus commit
+# height - the tag name does not set it. Read the version to tag off a green main run's step
+# summary ("Report computed version" in dotnet.yml) and create the release with exactly that
+# tag; the guard step below fails the run on any mismatch rather than publishing a package
+# that disagrees with its release. A leading "v" is accepted and stripped, matching
+# publicReleaseRefSpec in version.json.
+#
+# Deliberately does not run tests: the commit being released already passed CI, and this job's
+# only job is to reproduce that build and push it. Runs on Windows to match dotnet.yml, since
+# the solution includes a net48 leg and that is the configuration CI already proves.
+
+name: Release
+
+on:
+  release:
+    types: [published]
+  # dry run: everything except the tag check and the push, so the pipeline can be proven
+  # (and the packages inspected, via the run artifact) without cutting a release
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    environment: release
+    permissions:
+      id-token: write # for the OIDC exchange with nuget.org
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # depth is needed for nbgv
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            10.0.x
+
+      - uses: dotnet/nbgv@master
+        with:
+          setAllVars: true
+
+      - name: Verify tag matches computed version
+        if: github.event_name == 'release'
+        run: |
+          $computed = nbgv get-version --variable NuGetPackageVersion
+          $tag = "${{ github.event.release.tag_name }}" -replace '^v', ''
+          if ($computed -ne $tag) {
+            Write-Output "::error::Tag '$tag' does not match the computed version '$computed'; retag the release commit so the two agree."
+            exit 1
+          }
+          "### Publishing: ``$computed``" >> $env:GITHUB_STEP_SUMMARY
+          Write-Output "Publishing $computed"
+
+      - name: Restore dependencies
+        run: dotnet restore Build.csproj
+
+      - name: Purge
+        run: del src/Dapper.*/bin/Release/Dapper.*.nupkg
+
+      # both src projects set GeneratePackageOnBuild for Release, so this produces
+      # Dapper.AOT and Dapper.Advisor without a separate pack step
+      - name: Build
+        run: dotnet build Build.csproj --no-restore -c Release
+
+      - name: Collect packages
+        run: |
+          New-Item -ItemType Directory -Force -Path .nupkgs | Out-Null
+          Copy-Item src/Dapper.*/bin/Release/Dapper.*.nupkg .nupkgs/
+          Get-ChildItem .nupkgs/*.nupkg | ForEach-Object { Write-Output $_.Name }
+
+      # the packages survive as a run artifact even if the push fails
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: .nupkgs/*.nupkg
+
+      - name: NuGet login (OIDC to temp API key)
+        if: github.event_name == 'release'
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Push to nuget.org
+        if: github.event_name == 'release'
+        run: dotnet nuget push .nupkgs/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build](https://github.com/DapperLib/DapperAOT/actions/workflows/dotnet.yml/badge.svg)](https://github.com/DapperLib/DapperAOT/actions/workflows/dotnet.yml)
+[![Dapper.AOT](https://img.shields.io/nuget/v/Dapper.AOT?label=Dapper.AOT)](https://www.nuget.org/packages/Dapper.AOT)
+[![Dapper.Advisor](https://img.shields.io/nuget/v/Dapper.Advisor?label=Dapper.Advisor)](https://www.nuget.org/packages/Dapper.Advisor)
+
 Let's face it: ADO.NET is a complicated API, and writing "good" ADO.NET code by hand is time consuming and error-prone. But a lot of times you also don't want
 the ceremony of an ORM like EF or LLBLGenPro - you just want to execute SQL!
 

--- a/test/Dapper.AOT.Test/Interceptors/CommandDefinitionOverloads.output.netfx.txt
+++ b/test/Dapper.AOT.Test/Interceptors/CommandDefinitionOverloads.output.netfx.txt
@@ -1,4 +1,10 @@
-Generator produced 1 diagnostics:
+Generator produced 3 diagnostics:
 
 Hidden DAP000  L1 C1
-Dapper.AOT handled 1 of 3 enabled call-sites (0 unsupported API, 0 refused with diagnostics, 2 skipped silently) using 1 interceptors, 1 commands and 0 readers
+Dapper.AOT handled 1 of 3 enabled call-sites (0 unsupported API, 2 refused with diagnostics, 0 skipped silently) using 1 interceptors, 1 commands and 0 readers
+
+Info DAP057 Interceptors/CommandDefinitionOverloads.input.cs L18 C24
+'Query' passes its SQL inside a CommandDefinition, which Dapper.AOT cannot read at build time; use the overload that takes the SQL directly. This call-site is left on vanilla Dapper, which will not work under native AOT
+
+Info DAP057 Interceptors/CommandDefinitionOverloads.input.cs L19 C24
+'Execute' passes its SQL inside a CommandDefinition, which Dapper.AOT cannot read at build time; use the overload that takes the SQL directly. This call-site is left on vanilla Dapper, which will not work under native AOT

--- a/version.json
+++ b/version.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.1",
-  "versionHeightOffset": -1,
+  "versionHeightOffset": -3,
   "assemblyVersion": "1.0.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
-    "^refs/tags/v\\d+\\.\\d+"
+    "^refs/tags/v?\\d+\\.\\d+"
   ],
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
Three things, all in service of cutting **1.1.0** cleanly.

## 1. Land on 1.1.0

`versionHeightOffset` goes `-1` → `-3`.

The offset is a fixed *shift*, not a pin: height counts commits since the `version` property changed, and two more have landed since it opened (#221, plus this commit). Editing `versionHeightOffset` does **not** reset the height — verified, it stays at 3 — so the offset has to absorb the drift:

| | height | + offset | version |
| --- | --- | --- | --- |
| `-1` (current) | 3 | 2… wait, 1 | 1.1.1 |
| **`-3`** | 3 | 0 | **1.1.0** |

Confirmed locally: `{'VersionHeight': 3, 'BuildNumber': 0, 'NuGetPackageVersion': '1.1.0-…'}`. The `-g` suffix there is only because a branch isn't a public-release ref; main will compute a clean `1.1.0`, since a squash-merge puts exactly one commit on top of `78f0fc7` — the same height I measured.

## 2. Fix the release-tag pattern — it has never worked

`publicReleaseRefSpec` requires `^refs/tags/v\d+\.\d+`, but **every tag this repo has ever cut is unprefixed**: `1.0.52`, `1.0.48`, `1.0.45`, … The regex cannot match any of them.

Demonstrated on real history — checking out the actual `1.0.52` tag and asking nbgv:

```
{'NuGetPackageVersion': '1.0.52-g7a36975e31', 'PublicRelease': False}
```

So a tag-triggered build has always produced a `-g`-suffixed version; the packages that actually shipped must have come from `main` builds instead, which is why this was never noticed. Relaxed to `v?` so both spellings work — at an unprefixed `1.1.0` tag nbgv now reports a clean `1.1.0`, `PublicRelease: True`.

Same fix, same reason, as StackExchange.Redis [`611e478`](https://github.com/StackExchange/StackExchange.Redis/commit/611e478ffd1ef508e999f320c3de2691145eb76c) — which also had to bump the offset in the same commit, for the same "one more commit" reason.

## 3. Report the computed version in CI

Modelled on StackExchange.Redis's `CI.yml`:

```yaml
- name: Report computed version
  run: |
    $version = nbgv get-version --variable NuGetPackageVersion
    "### Computed package version: ``$version``" >> $env:GITHUB_STEP_SUMMARY
    Write-Output "Computed package version: $version"
```

Placed **before** restore/build, so the version stays legible even when a later step fails. Cutting a release then means reading that line off a green `main` build and tagging with exactly it.

## Checking this PR's own run

Two things to eyeball when CI goes green here:

- the step summary should read `1.1.0-g<hash>` — the `-g` is expected on a PR branch, and becomes clean `1.1.0` on main;
- the step working at all confirms `nbgv` is on PATH after the `dotnet/nbgv` action (its README says it installs the CLI, but this is the first step to depend on that).

---

## 4. Add `release.yml` (second commit)

There was **no release workflow at all** — `dotnet.yml` pushes to MyGet on main, and nothing publishes to nuget.org, so every release to date must have been pushed by hand. That is also why the broken tag pattern above went unnoticed for so long.

Triggered by a published GitHub Release, with `workflow_dispatch` as a dry run that does everything *except* the tag check and the push — so the pipeline can be proven, and the packages inspected via the run artifact, without cutting a release.

**The guard is the point.** nbgv computes the version from `version.json` + commit height, so the tag name does not set it; a mistyped tag would otherwise ship a package that disagrees with its release. The step compares the two and fails loudly instead. A leading `v` is stripped, matching the `v?` pattern fixed above.

Publishes **both** packages — `Dapper.AOT` and `Dapper.Advisor` are both on nuget.org at 1.0.52, and both set `GeneratePackageOnBuild` for Release, so a Release build produces the pair and the collect step gathers them with the same glob `dotnet.yml` already uses. They upload as a run artifact *before* the push, so a failed push doesn't cost the build.

### Setup needed outside this repo (also recorded in the file header)

- a GitHub **environment** named `release`;
- a **`NUGET_USER`** repository secret holding the nuget.org profile to publish as;
- a Trusted Publishing policy on nuget.org for **each of the two packages** — Repository Owner `DapperLib`, Repository `DapperAOT`, Workflow File `release.yml`, Environment `release`.

## No further offset delta needed

Adding a second commit to this branch does *not* need another `versionHeightOffset` change: the repo squash-merges, so this lands as **one** commit on main regardless. Simulated it rather than assuming — squash-merging this branch onto `main` gives:

```
{'VersionHeight': 3, 'BuildNumber': 0, 'NuGetPackageVersion': '1.1.0-…'}
```

`-3` still computes **1.1.0**. (The `-g` suffix is only because the simulation branch isn't `main`.)
