### PR TITLE
Fix the release artifact: .nupkgs is hidden, so it uploaded nothing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,18 +76,21 @@ jobs:
       - name: Build
         run: dotnet build Build.csproj --no-restore -c Release
 
+      # note: NOT ".nupkgs" - actions/upload-artifact excludes hidden files by default, so a
+      # dot-directory uploads as an empty artifact (with only a warning). Caught by the first
+      # dry run of this workflow
       - name: Collect packages
         run: |
-          New-Item -ItemType Directory -Force -Path .nupkgs | Out-Null
-          Copy-Item src/Dapper.*/bin/Release/Dapper.*.nupkg .nupkgs/
-          Get-ChildItem .nupkgs/*.nupkg | ForEach-Object { Write-Output $_.Name }
+          New-Item -ItemType Directory -Force -Path nupkgs | Out-Null
+          Copy-Item src/Dapper.*/bin/Release/Dapper.*.nupkg nupkgs/
+          Get-ChildItem nupkgs/*.nupkg | ForEach-Object { Write-Output $_.Name }
 
       # the packages survive as a run artifact even if the push fails
       - name: Upload packages
         uses: actions/upload-artifact@v4
         with:
           name: packages
-          path: .nupkgs/*.nupkg
+          path: nupkgs/*.nupkg
 
       - name: NuGet login (OIDC to temp API key)
         if: github.event_name == 'release'
@@ -98,4 +101,4 @@ jobs:
 
       - name: Push to nuget.org
         if: github.event_name == 'release'
-        run: dotnet nuget push .nupkgs/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push nupkgs/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.1",
-  "versionHeightOffset": -3,
+  "versionHeightOffset": -4,
   "assemblyVersion": "1.0.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
The first dry run of `release.yml` went **green while quietly producing no artifact**:

```
##[warning]No files were found with the provided path: .nupkgs/*.nupkg. No artifacts will be uploaded.
```

The packages themselves were fine — the log shows `Dapper.AOT.1.1.0.nupkg` and `Dapper.Advisor.1.1.0.nupkg` built and collected, at the right version. But **`actions/upload-artifact` excludes hidden files by default**, and `.nupkgs` is a dot-directory, so the upload matched nothing and merely warned.

That matters because the artifact is the "packages survive a failed push" guarantee — it would have been missing at exactly the moment it was needed, and the run would still have been green.

Dropped the dot rather than setting `include-hidden-files: true`, so it doesn't depend on an action input whose default could shift again, and left a comment so nobody tidies it back.

## Version

`versionHeightOffset` `-3` → `-4`: this is another commit on main and the target is still **1.1.0**. Simulated the squash rather than assuming — `{'VersionHeight': 4, 'BuildNumber': 0, 'NuGetPackageVersion': '1.1.0'}`.

## Worth noting about the dry run

This is the value of running it before tagging: a workflow that had never executed went green on its first outing and was still wrong. Once this merges, a second dispatch run should be checked for the artifact actually appearing on the run — not just for a green tick.