### PR TITLE
Push each package by path: pwsh does not expand the glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,17 @@ jobs:
         with:
           user: ${{ secrets.NUGET_USER }}
 
+      # push each file by full path rather than passing a glob: this job runs on Windows, where
+      # pwsh does not expand wildcards in arguments, so `dotnet nuget push nupkgs/*.nupkg` arrives
+      # literally and fails with "File does not exist". (The upstream this was modelled on runs on
+      # Linux, where bash expands it first.) --skip-duplicate so a partial push is safely re-runnable
       - name: Push to nuget.org
         if: github.event_name == 'release'
-        run: dotnet nuget push nupkgs/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          $packages = Get-ChildItem nupkgs/*.nupkg
+          if (-not $packages) { throw "no packages to push" }
+          foreach ($p in $packages) {
+            Write-Output "Pushing $($p.Name)"
+            dotnet nuget push $p.FullName --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            if ($LASTEXITCODE -ne 0) { throw "push failed for $($p.Name)" }
+          }

--- a/notes/state-of-play.md
+++ b/notes/state-of-play.md
@@ -12,6 +12,9 @@ Phases 1 and 2 of [plan.md](plan.md) are done and merged. Phase 3 (close the gap
 per round, each verified by a DB-backed run) is in progress; see
 [harness-baseline.md](harness-baseline.md) for the round log and the current numbers.
 
+**1.1.0 shipped 2026-09-11** - the first release since 1.0.52 (May), and the first to publish via
+release.yml rather than by hand. See "Releasing" below for the procedure and its two traps.
+
 Last measured baseline (**round 15, 2026-09-11**, Linux rig): **729 passed / 800** on the Dapper
 suite with **432 of 736** call-sites handled; the vanilla control on the same box is 770/800.
 All 41 divergences are known gaps, ×2 providers - no new failure class.
@@ -108,6 +111,35 @@ pushed**. Two things to know before trusting a number from it:
 - **absolute call-site counts are rig-specific.** The old rig's 533/725 cannot be reproduced here
   and the round-12 generator does not reproduce it either, so the difference is configuration
   that no longer exists. Compare within a rig.
+
+## Releasing (learned the hard way, 2026-09-11 cutting 1.1.0)
+
+The procedure that works:
+
+1. read the version off a **green main run**'s step summary ("Report computed version" in
+   dotnet.yml). A PR run reports the `refs/pull/N/merge` number, which is *not* what will ship -
+   the step says which it is;
+2. create a GitHub Release tagged with exactly that, **unprefixed** (`1.1.0`, not `v1.1.0`);
+   `publicReleaseRefSpec` accepts both since the `v?` fix, and every tag this repo has ever cut
+   is unprefixed;
+3. release.yml verifies tag == computed version and refuses to publish on a mismatch.
+
+Two things that cost time, so they are written down:
+
+- **`NUGET_USER` must be the policy *creator*, not the policy *owner*.** Trusted Publishing
+  policies are created from your own nuget.org account with an owner dropdown; choosing the
+  `Dapper` org there is what scopes the policy to org-owned packages, but the token exchange
+  looks up policies *created by* the username you pass. Passing `Dapper` gives
+  `HTTP 401 ... No matching trust policy owned by user`;
+- `versionHeightOffset` is a **fixed shift, not a pin**. Every commit that lands on main before
+  the tag moves the computed patch, so re-check `nbgv get-version` on main and decrement the
+  offset if the target has drifted. Simulate a squash-merge (`git merge --squash` onto a temp
+  branch off main) rather than reasoning about it - branch-local numbers are misleading, since
+  the repo squash-merges.
+
+Not a real concern, having checked: the per-version "uploaded by" on the Versions tab is visible
+only to owners. Anonymously the package page shows **Owners** only, and both packages already
+list `Dapper` and `marc.gravell`, so which identity pushes changes nothing a consumer sees.
 
 ## What is next, in the order parity.md argues for
 


### PR DESCRIPTION
The 1.1.0 release got all the way to the push and then failed:

```
error: File does not exist (nupkgs/*.nupkg).
```

This job runs on `windows-latest`, where **pwsh does not expand wildcards in arguments** — so `dotnet nuget push nupkgs/*.nupkg` arrived at `dotnet` literally. The workflow this was modelled on runs on `ubuntu-latest`, where bash expands the glob first, which is why the line looked correct.

No dry run could have caught it: the push is gated on `github.event_name == 'release'`, so it had never executed until there was a real release.

## The fix

Enumerate and push by full path, so it doesn't depend on shell behaviour:

```powershell
$packages = Get-ChildItem nupkgs/*.nupkg
if (-not $packages) { throw "no packages to push" }
foreach ($p in $packages) {
  dotnet nuget push $p.FullName --api-key ... --source https://api.nuget.org/v3/index.json --skip-duplicate
  if ($LASTEXITCODE -ne 0) { throw "push failed for $($p.Name)" }
}
```

Three deliberate details: it **throws when there are no packages** rather than silently pushing nothing (the same class of failure as the hidden-`.nupkgs` bug in #223, which was green-but-empty); it keeps `--skip-duplicate` so a partial push is safely re-runnable; and it checks `$LASTEXITCODE` per file, because a failing `dotnet` inside a `foreach` would not otherwise fail the step.

## 1.1.0 itself

Published by hand from the run artifact. The packages were already built correctly from the tagged commit, and re-running wouldn't have helped — a `release` event builds from the **tag**, so it would have rebuilt `0e071bf` without this fix. Getting the fix into 1.1.0 would have meant retagging and re-deriving the offset, to avoid two manual pushes of packages CI had already validated.

**The OIDC half now works**: `NuGet login` succeeded on the re-run once `NUGET_USER` was the policy *creator*.

## Also: the release procedure is written down

`state-of-play.md` gains a "Releasing" section — the steps, plus the two things that cost real time:

- **`NUGET_USER` is the policy creator, not the policy owner.** Policies are created from your own nuget.org account with an owner dropdown; picking the `Dapper` org there scopes the policy to org-owned packages, but the token exchange looks up policies *created by* the username passed. Passing `Dapper` gives `HTTP 401 … No matching trust policy owned by user`.
- **`versionHeightOffset` is a fixed shift, not a pin** — it drifts with every commit landing on main before the tag. Simulate a squash-merge rather than reasoning about it, since branch-local numbers mislead.

## Version

**No offset change.** With 1.1.0 published, main should now move on to **1.1.1**, which `-4` gives naturally — simulated: `{'VersionHeight': 5, 'BuildNumber': 1, 'NuGetPackageVersion': '1.1.1'}`.